### PR TITLE
Radar: first systematic historical backfill batch

### DIFF
--- a/data/CANDIDATES.md
+++ b/data/CANDIDATES.md
@@ -1,5 +1,193 @@
 # Radar candidates
 
-No pending candidates on the default branch. Automated proposals appear in
-the weekly Radar pull request.
+Automated proposals only; inclusion requires human review.
 
+| Date | Paper | Sources | Signal | Suggested direction |
+|---|---|---|---:|---|
+| 2026-05-13 | [MAPLE: Latent Multi-Agent Play for End-to-End Autonomous Driving](https://arxiv.org/abs/2605.14201) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-13 | [SCORP: Scene-Consistent Multi-agent Diffusion Planning with Stable Online Reinforcement Post-Training for Cooperative Driving](https://arxiv.org/abs/2604.11734) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-12-15 | [Post-Training and Test-Time Scaling of Generative Agent Behavior Models for Interactive Autonomous Driving](https://arxiv.org/abs/2512.13262) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-07-28 | [DriveAgent-R1: Advancing VLM-based Autonomous Driving with Active Perception and Hybrid Thinking](https://arxiv.org/abs/2507.20879) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-05-25 | [VTool-R1: VLMs Learn to Think with Images via Reinforcement Learning on Multimodal Tool Use](https://arxiv.org/abs/2505.19255) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-05-20 | [DeepEyes: Incentivizing "Thinking with Images" via Reinforcement Learning](https://arxiv.org/abs/2505.14362) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-04-14 | [GUI-R1 : A Generalist R1-Style Vision-Language Action Model For GUI Agents](https://arxiv.org/abs/2504.10458) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-02-26 | [Agentic Reward Modeling: Integrating Human Preferences with Verifiable Correctness Signals for Reliable Reward Systems](https://arxiv.org/abs/2502.19328) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-19 | [Supervising the search process produces reliable and generalizable information-seeking agents](https://arxiv.org/abs/2502.13957) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-12 | [I Think, Therefore I Diffuse: Enabling Multimodal In-Context Reasoning in Diffusion Models](https://arxiv.org/abs/2502.10458) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-04 | [QLASS: Boosting Language Agent Inference via Q-Guided Stepwise Search](https://arxiv.org/abs/2502.02584) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-01-09 | [Search-o1: Agentic Search-Enhanced Large Reasoning Models](https://arxiv.org/abs/2501.05366) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-01-03 | [Virgo: A Preliminary Exploration on Reproducing o1-like MLLM](https://arxiv.org/abs/2501.01904) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-12-30 | [Slow Perception: Let's Perceive Geometric Figures Step-by-step](https://arxiv.org/abs/2412.20631) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-12-23 | [Diving into Self-Evolving Training for Multimodal Reasoning](https://arxiv.org/abs/2412.17451) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-12-04 | [Scaling Inference-Time Search with Vision Value Model for Improved Visual Comprehension](https://arxiv.org/abs/2412.03704) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2023-08-17 | [Reinforced Self-Training (ReST) for Language Modeling](https://arxiv.org/abs/2308.08998) | curated:on-policy-post-training, curated:preference-learning | 5 | `needs-review` |
+| 2026-07-05 | [dOPSD: On-Policy Self-Distillation for Diffusion Language Models](https://arxiv.org/abs/2607.04428) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-16 | [Learning from the Self-future: On-policy Self-distillation for dLLMs](https://arxiv.org/abs/2606.18195) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-22 | [DiLaDiff: Distilled Latent-Augmented Diffusion for Language Modeling](https://arxiv.org/abs/2605.23605) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-21 | [Visual-Advantage On-Policy Distillation for Vision-Language Models](https://arxiv.org/abs/2605.21924) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-05-20 | [Distill to Think, Foresee to Act: Cognitive-Physical Reinforcement Learning for Autonomous Driving](https://arxiv.org/abs/2605.21139) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-06 | [FlowLM: Few-Step Language Modeling via Diffusion-to-Flow Adaptation](https://arxiv.org/abs/2605.20199) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-18 | [Vision-OPD: Learning to See Fine Details for Multimodal LLMs via On-Policy Self-Distillation](https://arxiv.org/abs/2605.18740) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-05-12 | [Self-Distilled Trajectory-Aware Boltzmann Modeling: Bridging the Training-Inference Discrepancy in Diffusion Language Models](https://arxiv.org/abs/2605.11854) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-11 | [Infinite Mask Diffusion for Few-Step Distillation](https://arxiv.org/abs/2605.10518) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-10 | [TAD: Temporal-Aware Trajectory Self-Distillation for Fast and Accurate Diffusion LLM](https://arxiv.org/abs/2605.09536) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-06 | [CRAFT: Counterfactual-to-Interactive Reinforcement Fine-Tuning for Driving Policies](https://arxiv.org/abs/2605.04470) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-05 | [Uni-OPD: Unifying On-Policy Distillation with a Dual-Perspective Recipe](https://arxiv.org/abs/2605.03677) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-04-30 | [Consistent Diffusion Language Models](https://arxiv.org/abs/2605.00161) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-04-29 | [Turning the TIDE: Cross-Architecture Distillation for Diffusion Large Language Models](https://arxiv.org/abs/2604.26951) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-03-06 | [X-OPD: Cross-Modal On-Policy Distillation for Capability Alignment in Speech LLMs](https://arxiv.org/abs/2603.24596) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-07-09 | [Post-Training in End-to-End Autonomous Driving](https://arxiv.org/abs/2607.08072) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-06-02 | [NVIDIA OmniDreams: Real-Time Generative World Model for Closed-Loop Autonomous Vehicle Simulation](https://arxiv.org/abs/2606.03159) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-30 | [DriveAnchor: Progressive Anchor-based Flow Learning for Autonomous Driving Planning](https://arxiv.org/abs/2606.00519) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-29 | [nuReasoning: A Reasoning-Centric Dataset and Benchmark for Long-Tail Autonomous Driving](https://arxiv.org/abs/2605.31572) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-29 | [Before Parc Fermé: RL-Time Pruning for Efficient Embodied LLMs in Autonomous Driving](https://arxiv.org/abs/2605.31256) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-27 | [SARAD: LLM-Based Safety-Aware Hybrid Reinforcement Learning with Collision Prediction for Autonomous Driving](https://arxiv.org/abs/2605.28583) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-22 | [Fast-dDrive: Efficient Block-Diffusion VLM for Autonomous Driving](https://arxiv.org/abs/2605.23163) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-19 | [VL-DPO: Vision-Language-Guided Finetuning for Preference-Aligned Autonomous Driving](https://arxiv.org/abs/2605.20082) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-19 | [SafeAlign-VLA: A Negative-Enhanced Safe Alignment Framework for Risk-Aware Autonomous Driving](https://arxiv.org/abs/2605.19524) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-11 | [C-CoT: Counterfactual Chain-of-Thought with Vision-Language Models for Safe Autonomous Driving](https://arxiv.org/abs/2605.10744) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-21 | [SpanVLA: Efficient Action Bridging and Learning from Negative-Recovery Samples for Vision-Language-Action Model](https://arxiv.org/abs/2604.19710) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-14 | [FeaXDrive: Feasibility-aware Trajectory-Centric Diffusion Planning for End-to-End Autonomous Driving](https://arxiv.org/abs/2604.12656) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-10 | [Learning Vision-Language-Action World Models for Autonomous Driving](https://arxiv.org/abs/2604.09059) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-03 | [ExploreVLA: Dense World Modeling and Exploration for End-to-End Autonomous Driving](https://arxiv.org/abs/2604.02714) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-05-22 | [LLaDA-V: Large Language Diffusion Models with Visual Instruction Tuning](https://arxiv.org/abs/2505.16933) | curated:diffusion-language-post-training, curated:multimodal-post-training | 5 | `needs-review` |
+| 2026-07-14 | [Accelerating Masked Diffusion Large Language Models: A Survey of Efficient Inference Techniques](https://arxiv.org/abs/2607.12829) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-28 | [Adaptive Block Diffusion: Resolving Training-Inference Mismatch in Diffusion Language Models](https://arxiv.org/abs/2606.29275) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-24 | [Improved Large Language Diffusion Models](https://arxiv.org/abs/2606.25331) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-04 | [Data-Efficient Autoregressive-to-Diffusion Language Models via On-Policy Distillation](https://arxiv.org/abs/2606.06712) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-31 | [Revise, Don't Freeze: Sampler-Matched Training for Self-Correcting Masked Diffusion Language Models](https://arxiv.org/abs/2606.01026) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-30 | [EPIC: Efficient and Parallel Inference under CFG Constraints for Diffusion Language Models](https://arxiv.org/abs/2606.00722) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-28 | [NaRA: Noise-Aware LoRA for Parameter-Efficient Fine-Tuning of Diffusion LLMs](https://arxiv.org/abs/2605.29716) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-18 | [Elastic-dLLM: Position Preserving Context Compression and Augmentation of Diffusion LLMs](https://arxiv.org/abs/2605.18165) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-16 | [Beyond Execution: Static-Analysis Rewards and Hint-Conditioned Diffusion RL for Code Generation](https://arxiv.org/abs/2605.17174) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-16 | [Constrained Code Generation with Discrete Diffusion](https://arxiv.org/abs/2605.16829) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-13 | [Beyond Mode-Seeking RL: Trajectory-Balance Post-Training for Diffusion Language Models](https://arxiv.org/abs/2605.13935) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-08 | [Guidance Is Not a Hyperparameter: Learning Dynamic Control in Diffusion Language Models](https://arxiv.org/abs/2605.07701) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-07 | [Don't Retrain, Align: Adapting Autoregressive LMs to Diffusion LMs via Representation Alignment](https://arxiv.org/abs/2605.06885) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-07-09 | [Reinforcing the Generation Order of Multimodal Masked Diffusion Models](https://arxiv.org/abs/2607.08056) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-22 | [dVLA-RL: Reinforcement Learning over Denoising Trajectories for Discrete Diffusion Vision-Language-Action Models](https://arxiv.org/abs/2606.23623) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-17 | [PerceptionDLM: Parallel Region Perception with Multimodal Diffusion Language Models](https://arxiv.org/abs/2606.19534) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-11 | [Efficient Reinforcement for Visual-Textual Thinking with Discrete Diffusion Model](https://arxiv.org/abs/2606.14792) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-06 | [Uncertainty-Aware Exploratory Direct Preference Optimization for Multimodal Large Language Models](https://arxiv.org/abs/2605.04874) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-04-22 | [LLaDA2.0-Uni: Unifying Multimodal Understanding and Generation with Diffusion Large Language Model](https://arxiv.org/abs/2604.20796) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-04-07 | [Thinking Diffusion: Penalize and Guide Visual-Grounded Reasoning in Diffusion Multimodal Language Models](https://arxiv.org/abs/2604.05497) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2024-06-11 | [Accessing GPT-4 level Mathematical Olympiad Solutions via Monte Carlo Tree Self-refine with LLaMa-3 8B](https://arxiv.org/abs/2406.07394) | curated:mbzuai-llm-post-training, curated:preference-learning | 5 | `needs-review` |
+| 2026-04-17 | [Towards Robust Endogenous Reasoning: Unifying Drift Adaptation in Non-Stationary Tuning](https://arxiv.org/abs/2604.15705) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-05 | [DARE: Diffusion Large Language Models Alignment and Reinforcement Executor](https://arxiv.org/abs/2604.04215) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-04-02 | [Causal Scene Narration with Runtime Safety Supervision for Vision-Language-Action Driving](https://arxiv.org/abs/2604.01723) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-26 | [Drive My Way: Preference Alignment of Vision-Language-Action Model for Personalized Driving](https://arxiv.org/abs/2603.25740) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-03 | [MoD-DPO: Towards Mitigating Cross-modal Hallucinations in Omni LLMs using Modality Decoupled Preference Optimization](https://arxiv.org/abs/2603.03192) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-01-02 | [DA-DPO: Cost-efficient Difficulty-aware Preference Optimization for Reducing MLLM Hallucinations](https://arxiv.org/abs/2601.00623) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-12-19 | [TakeAD: Preference-based Post-optimization for End-to-end Autonomous Driving with Expert Takeover Data](https://arxiv.org/abs/2512.17370) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-10-26 | [Aligning Diffusion Language Models via Unpaired Preference Optimization](https://arxiv.org/abs/2510.23658) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-10-02 | [Oracle-RLAIF: An Improved Fine-Tuning Framework for Multi-modal Video Models using Reinforcement Learning from Ranking Feedback](https://arxiv.org/abs/2510.02561) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-09-27 | [A2D: Any-Order, Any-Step Safety Alignment for Diffusion Language Models](https://arxiv.org/abs/2509.23286) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2024-06-06 | [ReST-MCTS*: LLM Self-Training via Process Reward Guided Tree Search](https://arxiv.org/abs/2406.03816) | curated:mbzuai-llm-post-training, curated:preference-learning | 5 | `needs-review` |
+| 2026-07-16 | [Mask-Aware Policy Gradients for Diffusion Language Models](https://arxiv.org/abs/2607.15200) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-07-16 | [A Continuous-Time Reinforcement Learning Framework for Fine-Tuning Discrete Diffusion Models](https://arxiv.org/abs/2607.14522) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-06-30 | [SLIM-RL: Risk-Budgeted Random-Masking RL for Diffusion LLMs Without Trajectory Slicing](https://arxiv.org/abs/2607.00208) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-08 | [DACA-GRPO: Denoising-Aware Credit Assignment for Reinforcement Learning in Diffusion Language Models](https://arxiv.org/abs/2605.16342) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-14 | [EponaV2: Driving World Model with Comprehensive Future Reasoning](https://arxiv.org/abs/2605.14696) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-05-11 | [Relative Score Policy Optimization for Diffusion Language Models](https://arxiv.org/abs/2605.10218) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-03-26 | [LanteRn: Latent Visual Structured Reasoning](https://arxiv.org/abs/2603.25629) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-03-13 | [Reinforcement Learning for Diffusion LLMs with Entropy-Guided Step Selection and Stepwise Advantages](https://arxiv.org/abs/2603.12554) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-03-02 | [LFPO: Likelihood-Free Policy Optimization for Masked Diffusion Models](https://arxiv.org/abs/2603.01563) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-02-25 | [MindDriver: Introducing Progressive Multimodal Reasoning for Autonomous Driving](https://arxiv.org/abs/2602.21952) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-02-24 | [NoRD: A Data-Efficient Vision-Language-Action Model that Drives without Reasoning](https://arxiv.org/abs/2602.21172) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-02-06 | [Diffusion-State Policy Optimization for Masked Diffusion Language Models](https://arxiv.org/abs/2602.06462) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-01-21 | [The Flexibility Trap: Rethinking the Value of Arbitrary Order in Diffusion Language Models](https://arxiv.org/abs/2601.15165) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-05-12 | [Driving Intents Amplify Planning-Oriented Reinforcement Learning](https://arxiv.org/abs/2605.12625) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-04-16 | [RAD-2: Scaling Reinforcement Learning in a Generator-Discriminator Framework](https://arxiv.org/abs/2604.15308) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-30 | [$AutoDrive\text{-}P^3$: Unified Chain of Perception-Prediction-Planning Thought via Reinforcement Fine-Tuning](https://arxiv.org/abs/2603.28116) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-25 | [DreamerAD: Efficient Reinforcement Learning via Latent World Model for Autonomous Driving](https://arxiv.org/abs/2603.24587) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-14 | [Fine-tuning is Not Enough: A Parallel Framework for Collaborative Imitation and Reinforcement Learning in End-to-end Autonomous Driving](https://arxiv.org/abs/2603.13842) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-02-26 | [dLLM: Simple Diffusion Language Modeling](https://arxiv.org/abs/2602.22661) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-02-25 | [PanoEnv: Exploring 3D Spatial Intelligence in Panoramic Environments with Reinforcement Learning](https://arxiv.org/abs/2602.21992) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-02-11 | [Found-RL: foundation model-enhanced reinforcement learning for autonomous driving](https://arxiv.org/abs/2602.10458) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-01-08 | [ThinkDrive: Chain-of-Thought Guided Progressive Reinforcement Learning Fine-Tuning for Autonomous Driving](https://arxiv.org/abs/2601.04714) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-12-23 | [DiRL: An Efficient Post-Training Framework for Diffusion Language Models](https://arxiv.org/abs/2512.22234) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-16 | [OmniDrive-R1: Reinforcement-driven Interleaved Multi-modal Chain-of-Thought for Trustworthy Vision-Language Autonomous Driving](https://arxiv.org/abs/2512.14044) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-12-06 | [WAM-Diff: A Masked Diffusion VLA Framework with MoE and Online Reinforcement Learning for Autonomous Driving](https://arxiv.org/abs/2512.11872) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2022-11-25 | [Solving math word problems with process- and outcome-based feedback](https://arxiv.org/abs/2211.14275) | curated:mbzuai-llm-post-training, curated:preference-learning | 5 | `needs-review` |
+| 2026-03-26 | [Neuro-Cognitive Reward Modeling for Human-Centered Autonomous Vehicle Control](https://arxiv.org/abs/2603.25968) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-05-23 | [Guided by Gut: Efficient Test-Time Scaling with Reinforced Intrinsic Confidence](https://arxiv.org/abs/2505.20325) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-04-17 | [LLMs Meet Finance: Fine-Tuning Foundation Models for the Open FinLLM Leaderboard](https://arxiv.org/abs/2504.13125) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-03-13 | [VisualPRM: An Effective Process Reward Model for Multimodal Reasoning](https://arxiv.org/abs/2503.10291) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-02-20 | [Multimodal RewardBench: Holistic Evaluation of Reward Models for Vision Language Models](https://arxiv.org/abs/2502.14191) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-19 | [AdaptiveStep: Automatically Dividing Reasoning Step through Model Confidence](https://arxiv.org/abs/2502.13943) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-16 | [Uncertainty-Aware Step-wise Verification with Generative Reward Models](https://arxiv.org/abs/2502.11250) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-13 | [Self-Consistency of the Internal Reward Models Improves Self-Rewarding Language Models](https://arxiv.org/abs/2502.08922) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-10 | [Can 1B LLM Surpass 405B LLM? Rethinking Compute-Optimal Test-Time Scaling](https://arxiv.org/abs/2502.06703) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-01-14 | [ReARTeR: Retrieval-Augmented Reasoning with Trustworthy Process Rewarding](https://arxiv.org/abs/2501.07861) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-01-13 | [The Lessons of Developing Process Reward Models in Mathematical Reasoning](https://arxiv.org/abs/2501.07301) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-01-06 | [PRMBench: A Fine-grained and Challenging Benchmark for Process-Level Reward Models](https://arxiv.org/abs/2501.03124) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-01-02 | [ToolComp: A Multi-Tool Reasoning & Process Supervision Benchmark](https://arxiv.org/abs/2501.01290) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2026-05-21 | [Learnability-Informed Fine-Tuning of Diffusion Language Models](https://arxiv.org/abs/2605.22939) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-04-06 | [The Blind Spot of Adaptation: Quantifying and Mitigating Forgetting in Fine-tuned Driving Models](https://arxiv.org/abs/2604.04857) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-18 | [VLM-AutoDrive: Post-Training Vision-Language Models for Safety-Critical Autonomous Driving Events](https://arxiv.org/abs/2603.18178) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-12 | [Less Data, Faster Convergence: Goal-Driven Data Optimization for Multimodal Instruction Tuning](https://arxiv.org/abs/2603.12478) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-03-02 | [LaST-VLA: Thinking in Latent Spatio-Temporal Space for Vision-Language-Action in Autonomous Driving](https://arxiv.org/abs/2603.01928) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-01-19 | [PlannerRFT: Reinforcing Diffusion Planners through Closed-Loop and Sample-Efficient Fine-Tuning](https://arxiv.org/abs/2601.12901) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-01-06 | [Empowering Reliable Visual-Centric Instruction Following in MLLMs](https://arxiv.org/abs/2601.03198) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-03-08 | [A Survey on Post-training of Large Language Models](https://arxiv.org/abs/2503.06072) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-28 | [LLM Post-Training: A Deep Dive into Reasoning Large Language Models](https://arxiv.org/abs/2502.21321) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-26 | [Two Heads Are Better Than One: Dual-Model Verbal Reflection at Inference-Time](https://arxiv.org/abs/2502.19230) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-26 | [BIG-Bench Extra Hard](https://arxiv.org/abs/2502.19187) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-25 | [LeanProgress: Guiding Search for Neural Theorem Proving via Proof Progress Prediction](https://arxiv.org/abs/2502.17925) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-20 | [SuperGPQA: Scaling LLM Evaluation across 285 Graduate Disciplines](https://arxiv.org/abs/2502.14739) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-17 | [LIMR: Less is More for RL Scaling](https://arxiv.org/abs/2502.11886) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-02-06 | [Value-Based Deep RL Scales Predictably](https://arxiv.org/abs/2502.04327) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-01-24 | [Humanity's Last Exam](https://arxiv.org/abs/2501.14249) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-12-30 | [Do NOT Think That Much for 2+3=? On the Overthinking of o1-Like LLMs](https://arxiv.org/abs/2412.21187) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-12-14 | [Proposing and solving olympiad geometry with guided tree search](https://arxiv.org/abs/2412.10673) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-11-07 | [GPT-Guided Monte Carlo Tree Search for Symbolic Regression in Financial Fraud Detection](https://arxiv.org/abs/2411.04459) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-10-31 | [What Happened in LLMs Layers when Trained for Fast vs. Slow Thinking: A Gradient Perspective](https://arxiv.org/abs/2410.23743) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-10-23 | [Understanding When Tree of Thoughts Succeeds: Larger Models Excel in Generation, Not Discrimination](https://arxiv.org/abs/2410.17820) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2024-09-23 | [A Preliminary Study of o1 in Medicine: Are We Closer to an AI Doctor?](https://arxiv.org/abs/2409.15277) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2026-03-16 | [Learning from Mistakes: Post-Training for Driving VLA with Takeover Data](https://arxiv.org/abs/2603.14972) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-03-06 | [Omni-Diffusion: Unified Multimodal Understanding and Generation with Masked Discrete Diffusion](https://arxiv.org/abs/2603.06577) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-03-01 | [Unleashing VLA Potentials in Autonomous Driving via Explicit Learning from Failures](https://arxiv.org/abs/2603.01063) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-02-26 | [Unleashing the Potential of Diffusion Models for End-to-End Autonomous Driving](https://arxiv.org/abs/2602.22801) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-02-25 | [The Design Space of Tri-Modal Masked Diffusion Models](https://arxiv.org/abs/2602.21472) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-02-05 | [AnCoder: Anchored Code Generation via Discrete Diffusion Models](https://arxiv.org/abs/2602.17688) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-02-15 | [LaViDa-R1: Advancing Reasoning for Unified Multimodal Diffusion Language Models](https://arxiv.org/abs/2602.14147) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-02-03 | [Video-OPD: Efficient Post-Training of Multimodal Large Language Models for Temporal Video Grounding via On-Policy Distillation](https://arxiv.org/abs/2602.02994) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2026-02-01 | [DreamOn: Diffusion Language Models For Code Infilling Beyond Fixed-size Canvas](https://arxiv.org/abs/2602.01326) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-01-22 | [Stable-DiffCoder: Pushing the Frontier of Code Diffusion Large Language Model](https://arxiv.org/abs/2601.15892) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-01-21 | [Mechanism Shift During Post-training from Autoregressive to Masked Diffusion Language Models](https://arxiv.org/abs/2601.14758) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-01-16 | [T$^\star$: Progressive Block Scaling for Masked Diffusion Language Models Through Trajectory Aware Reinforcement Learning](https://arxiv.org/abs/2601.11214) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-01-12 | [d3LLM: Ultra-Fast Diffusion LLM using Pseudo-Trajectory Distillation](https://arxiv.org/abs/2601.07568) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2026-01-09 | [FLARE: Learning Future-Aware Latent Representations from Vision-Language Models for Autonomous Driving](https://arxiv.org/abs/2601.05611) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2026-01-05 | [CD4LM: Consistency Distillation and aDaptive Decoding for Diffusion Language Models](https://arxiv.org/abs/2601.02236) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-30 | [Counterfactual VLA: Self-Reflective Vision-Language-Action Model with Adaptive Reasoning](https://arxiv.org/abs/2512.24426) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-12-28 | [WeDLM: Reconciling Diffusion Language Models with Standard Causal Attention for Fast Inference](https://arxiv.org/abs/2512.22737) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-24 | [dUltra: Ultra-Fast Diffusion Language Models via Reinforcement Learning](https://arxiv.org/abs/2512.21446) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-20 | [LLaViDA: A Large Language Vision Driving Assistant for Explicit Reasoning and Enhanced Trajectory Planning](https://arxiv.org/abs/2512.18211) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-12-18 | [Vision-Language-Action Models for Autonomous Driving: Past, Present, and Future](https://arxiv.org/abs/2512.16760) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-12-10 | [LLaDA2.0: Scaling Up Diffusion Language Models to 100B](https://arxiv.org/abs/2512.15745) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-17 | [DiffusionVL: Translating Any Autoregressive Models into Diffusion Vision Language Models](https://arxiv.org/abs/2512.15713) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-17 | [Corrective Diffusion Language Models](https://arxiv.org/abs/2512.15596) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-16 | [SDAR-VL: Stable and Efficient Block-wise Diffusion for Vision-Language Understanding](https://arxiv.org/abs/2512.14068) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-16 | [Efficient-DLM: From Autoregressive to Diffusion Language Models, and Beyond in Speed](https://arxiv.org/abs/2512.14067) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-16 | [Sparse-LaViDa: Sparse Multimodal Discrete Diffusion Language Models](https://arxiv.org/abs/2512.14008) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-10 | [d-TreeRPO: Towards More Reliable Policy Optimization for Diffusion Language Models](https://arxiv.org/abs/2512.09675) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-09 | [Learning Unmasking Policies for Diffusion Language Models](https://arxiv.org/abs/2512.09106) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-08 | [DiffusionDriveV2: Reinforcement Learning-Constrained Truncated Diffusion Modeling in End-to-End Autonomous Driving](https://arxiv.org/abs/2512.07745) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-12-07 | [From Next-Token to Next-Block: A Principled Adaptation Path for Diffusion LLMs](https://arxiv.org/abs/2512.06776) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-03 | [Principled RL for Diffusion LLMs Emerges from a Sequence-Level Perspective](https://arxiv.org/abs/2512.03759) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-12-03 | [Colon-X: Advancing Intelligent Colonoscopy toward Clinical Reasoning](https://arxiv.org/abs/2512.03667) | curated:mbzuai-llm-post-training | 3 | `needs-review` |
+| 2025-11-26 | [Qwen3-VL Technical Report](https://arxiv.org/abs/2511.21631) | curated:multimodal-post-training | 3 | `needs-review` |
+| 2025-11-25 | [Reasoning-VLA: A Fast and General Vision-Language-Action Reasoning Model for Autonomous Driving](https://arxiv.org/abs/2511.19912) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-11-24 | [CDLM: Consistency Diffusion Language Models For Faster Sampling](https://arxiv.org/abs/2511.19269) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-11-12 | [MMaDA-Parallel: Multimodal Large Diffusion Language Models for Thinking-Aware Editing and Generation](https://arxiv.org/abs/2511.09611) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-10-30 | [Alpamayo-R1: Bridging Reasoning and Action Prediction for Generalizable Autonomous Driving in the Long Tail](https://arxiv.org/abs/2511.00088) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-10-30 | [WOD-E2E: Waymo Open Dataset for End-to-End Driving in Challenging Long-tail Scenarios](https://arxiv.org/abs/2510.26125) | curated:autonomous-driving-post-training | 3 | `needs-review` |
+| 2025-10-24 | [MRO: Enhancing Reasoning in Diffusion Language Models via Multi-Reward Optimization](https://arxiv.org/abs/2510.21473) | curated:diffusion-language-post-training | 3 | `needs-review` |
+| 2025-10-22 | [From Denoising to Refining: A Corrective Framework for Vision-Language Diffusion Model](https://arxiv.org/abs/2510.19871) | curated:diffusion-language-post-training | 3 | `needs-review` |
+
+Review checklist:
+
+- Is there an actual learning or feedback loop after pretraining?
+- Is the primary direction correct?
+- Is the key idea factual and specific?
+- Is this already represented by another version or publication?

--- a/data/candidates.yaml
+++ b/data/candidates.yaml
@@ -1,2 +1,8275 @@
-papers: []
-
+papers:
+- id: arxiv:2605.14201
+  title: 'MAPLE: Latent Multi-Agent Play for End-to-End Autonomous Driving'
+  date: '2026-05-13'
+  updated: '2026-05-19'
+  url: https://arxiv.org/abs/2605.14201
+  abstract: 'Vision-language-action (VLA) models are effective as end-to-end motion planners, but can be brittle when evaluated
+    in closed-loop settings due to being trained under traditional imitation learning framework. Existing closed-loop supervision
+    approaches lack scalability and fail to completely model a reactive environment. We propose MAPLE, a novel framework for
+    reactive, multi-agent rollout of a dynamic driving scenario in the latent space of the VLA model. The ego vehicle and
+    nearby traffic agents are independently controlled over multi-step horizons, while being reactive to other agents in the
+    scene, enabling closed-loop training. MAPLE consists of two training stages: (1) supervised fine-tuning on the latent
+    rollouts based on ground-truth trajectories, followed by (2) reinforcement learning with global and agent -specific rewards
+    that encourage safety, progress, and interaction realism. We further propose diversity rewards that encourage the model
+    to generate planning behaviors that may not be present in logged driving data. Notably, our closed-loop training framework
+    is scalable and does not require external simulators, which can be computationally expensive to run and have limited visual
+    fidelity to the real-world. MAPLE achieves state-of-the-art driving performance on Bench2Drive and demonstrates scalable,
+    closed-loop multi-agent play for robust E2E autonomous driving systems.'
+  authors:
+  - Rajeev Yasarla
+  - Deepti Hegde
+  - Hsin-Pai Cheng
+  - Shizhong Han
+  - Yunxiao Shi
+  - Meysam Sadeghigooghari
+  - Hanno Ackermann
+  - Litian Liu
+  - Pranav Desai
+  - Fatih Porikli
+  - Mohammad Ghavamzadeh
+  - Hong Cai
+  arxiv_categories:
+  - cs.RO
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - agentic
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2604.11734
+  title: 'SCORP: Scene-Consistent Multi-agent Diffusion Planning with Stable Online Reinforcement Post-Training for Cooperative
+    Driving'
+  date: '2026-04-13'
+  updated: '2026-05-11'
+  url: https://arxiv.org/abs/2604.11734
+  abstract: 'Cooperative driving is a safety- and efficiency-critical task that requires the coordination of diverse, interaction-realistic
+    multi-agent trajectories. Although existing diffusion-based methods can capture multimodal behaviors from demonstrations,
+    they often exhibit weak scene consistency and poor alignment with closed-loop cooperative objectives. This makes post-training
+    necessary for further improvement, yet achieving stable online post-training in reactive multi-agent environments remains
+    challenging. In this paper, we propose SCORP, a scene-consistent multi-agent diffusion planner with stable online reinforcement
+    learning (RL) post-training for cooperative driving. For pre-training, we develop a scene-conditioned multi-agent denoising
+    architecture that couples inter-agent self-attention with a dual-path conditioning mechanism: cross-attention provides
+    direct scene-information injection, while AdaLN-Zero enables additional flexible and stable conditional modulation, thereby
+    improving the scene consistency and road adherence of joint trajectories. For post-training, we formulate a two-layer
+    Markov decision process (MDP) that explicitly integrates the reverse denoising chain with policy-environment interaction.
+    We further co-design dense, well-shaped planning rewards and variance-gated group-relative policy optimization (VG-GRPO)
+    to mitigate advantage collapse and gradient instability during closed-loop training. Extensive experiments show that SCORP
+    outperforms strong open-source baselines on WOMD, with 10.47%-28.26% and 1.70%-7.22% improvements in core safety and efficiency
+    metrics, respectively. Moreover, compared with alternative post-training methods, SCORP delivers significant and consistent
+    gains in both driving safety and traffic efficiency, highlighting stabl'
+  authors:
+  - Haojie Bai
+  - Aimin Li
+  - Ruoyu Yao
+  - Xiongwei Zhao
+  - Tingting Zhang
+  - Xing Zhang
+  - Lin Gao
+  - and Jun Ma
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - agentic
+  - generative-media
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2512.13262
+  title: Post-Training and Test-Time Scaling of Generative Agent Behavior Models for Interactive Autonomous Driving
+  date: '2025-12-15'
+  updated: '2025-12-15'
+  url: https://arxiv.org/abs/2512.13262
+  abstract: Learning interactive motion behaviors among multiple agents is a core challenge in autonomous driving. While imitation
+    learning models generate realistic trajectories, they often inherit biases from datasets dominated by safe demonstrations,
+    limiting robustness in safety-critical cases. Moreover, most studies rely on open-loop evaluation, overlooking compounding
+    errors in closed-loop execution. We address these limitations with two complementary strategies. First, we propose Group
+    Relative Behavior Optimization (GRBO), a reinforcement learning post-training method that fine-tunes pretrained behavior
+    models via group relative advantage maximization with human regularization. Using only 10% of the training dataset, GRBO
+    improves safety performance by over 40% while preserving behavioral realism. Second, we introduce Warm-K, a warm-started
+    Top-K sampling strategy that balances consistency and diversity in motion selection. Our Warm-K method-based test-time
+    scaling enhances behavioral consistency and reactivity at test time without retraining, mitigating covariate shift and
+    reducing performance discrepancies. Demo videos are available in the supplementary material.
+  authors:
+  - Hyunki Seong
+  - Jeong-Kyun Lee
+  - Heesoo Myeong
+  - Yongho Shin
+  - Hyun-Mook Cho
+  - Duck Hoon Kim
+  - Pranav Desai
+  - Monu Surana
+  arxiv_categories:
+  - cs.RO
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - agentic
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2507.20879
+  title: 'DriveAgent-R1: Advancing VLM-based Autonomous Driving with Active Perception and Hybrid Thinking'
+  date: '2025-07-28'
+  updated: '2026-04-20'
+  url: https://arxiv.org/abs/2507.20879
+  abstract: The advent of Vision-Language Models (VLMs) has significantly advanced end-to-end autonomous driving, demonstrating
+    powerful reasoning abilities for high-level behavior planning tasks. However, existing methods are often constrained by
+    a passive perception paradigm, relying solely on text-based reasoning. This passivity restricts the model's capacity to
+    actively seek crucial visual evidence when faced with uncertainty. To address this, we introduce DriveAgent-R1, the first
+    autonomous driving agent capable of active perception for planning. In complex scenarios, DriveAgent-R1 proactively invokes
+    tools to perform visual reasoning, firmly grounding its decisions in visual evidence, thereby enhancing both interpretability
+    and reliability. Furthermore, we propose a hybrid thinking framework, inspired by human driver cognitive patterns, allowing
+    the agent to adaptively switch between efficient text-only reasoning and robust tool-augmented visual reasoning based
+    on scene complexity. This capability is cultivated through a three-stage progressive training strategy, featuring a core
+    Cascaded Reinforcement Learning (Cascaded RL) phase. Extensive experiments on the Drive-Internal dataset, which is rich
+    in long-tail scenarios, and the public nuScenes dataset show that, with only 3B parameters, DriveAgent-R1 achieves competitive
+    performance comparable to top closed model systems such as GPT-5 and to human driving proficiency while remaining deployment-friendly,
+    offering a proven path toward building more intelligent autonomous driving systems.
+  authors:
+  - Weicheng Zheng
+  - Xiaofei Mao
+  - Nanfei Ye
+  - Pengxiang Li
+  - Kun Zhan
+  - Xianpeng Lang
+  - Hang Zhao
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - agentic
+  - embodied-vla
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2505.19255
+  title: 'VTool-R1: VLMs Learn to Think with Images via Reinforcement Learning on Multimodal Tool Use'
+  date: '2025-05-25'
+  updated: '2026-03-04'
+  url: https://arxiv.org/abs/2505.19255
+  abstract: Reinforcement Learning Finetuning (RFT) has significantly advanced the reasoning capabilities of large language
+    models (LLMs) by enabling long chains of thought, self-correction, and effective tool use. While recent works attempt
+    to extend RFT to vision-language models (VLMs), these efforts largely produce text-only reasoning conditioned on static
+    image inputs, falling short of true multimodal reasoning in the response. In contrast, test-time methods like Visual Sketchpad
+    incorporate visual steps but lack training mechanisms. We introduce VTool-R1, the first framework that trains VLMs to
+    generate multimodal chains of thought by interleaving text and intermediate visual reasoning steps. VTool-R1 integrates
+    Python-based visual editing tools into the RFT process, enabling VLMs to learn when and how to generate visual reasoning
+    steps that benefit final reasoning. Trained with outcome-based rewards tied to task accuracy, our approach elicits strategic
+    visual tool use for reasoning without relying on process-based supervision. Experiments on structured visual question
+    answering over charts and tables show that VTool-R1 enhances reasoning performance by teaching VLMs to "think with images"
+    and generate multimodal chain of thoughts with tools. To support future research in multi-turn multi-modal reasoning,
+    we open-source our code at https://github.com/VTOOL-R1/vtool-r1
+  authors:
+  - Mingyuan Wu
+  - Jingcheng Yang
+  - Jize Jiang
+  - Meitang Li
+  - Kaizhuo Yan
+  - Hanchao Yu
+  - Minjia Zhang
+  - Chengxiang Zhai
+  - Klara Nahrstedt
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - agentic
+  - multimodal
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2505.14362
+  title: 'DeepEyes: Incentivizing "Thinking with Images" via Reinforcement Learning'
+  date: '2025-05-20'
+  updated: '2026-03-01'
+  url: https://arxiv.org/abs/2505.14362
+  abstract: Large Vision-Language Models excel at multimodal understanding but struggle to deeply integrate visual information
+    into their predominantly text-based reasoning processes, a key challenge in mirroring human cognition. To address this,
+    we introduce DeepEyes, a model that learns to "think with images", trained end-to-end with reinforcement learning without
+    requiring pre-collected reasoning data for cold-start supervised fine-tuning (SFT). Notably, this ability emerges natively,
+    leveraging the model's own grounding capability as an intrinsic function rather than relying on external specialized models
+    or APIs. We enable this capability through active perception, where the model learns to strategically ground its reasoning
+    in visual information, guided by a tailored data selection and reward strategy. DeepEyes achieves significant performance
+    gains on general perception and reasoning benchmarks and also demonstrates improvement in grounding, hallucination, and
+    mathematical reasoning tasks. Interestingly, we observe the distinct evolution of active perception from initial exploration
+    to efficient and accurate exploitation, and diverse thinking patterns that closely mirror human visual reasoning processes.
+    Code is available at https://github.com/Visual-Agent/DeepEyes.
+  authors:
+  - Ziwei Zheng
+  - Michael Yang
+  - Jack Hong
+  - Chenxiao Zhao
+  - Guohai Xu
+  - Le Yang
+  - Chao Shen
+  - Xing Yu
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - agentic
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2504.10458
+  title: 'GUI-R1 : A Generalist R1-Style Vision-Language Action Model For GUI Agents'
+  date: '2025-04-14'
+  updated: '2025-10-01'
+  url: https://arxiv.org/abs/2504.10458
+  abstract: Existing efforts in building Graphical User Interface (GUI) agents largely rely on the training paradigm of supervised
+    fine-tuning on Large Vision-Language Models (LVLMs). However, this approach not only demands extensive amounts of training
+    data but also struggles to effectively understand GUI screenshots and generalize to unseen interfaces. The issue significantly
+    limits its application in real-world scenarios, especially for high-level tasks. Inspired by Reinforcement Fine-Tuning
+    (RFT) in large reasoning models (e.g., DeepSeek-R1), which efficiently enhances the problem-solving capabilities of large
+    language models in real-world settings, we propose \name, the first reinforcement learning framework designed to enhance
+    the GUI capabilities of LVLMs in high-level real-world task scenarios, through unified action space rule modeling. By
+    leveraging a small amount of carefully curated high-quality data across multiple platforms (including Windows, Linux,
+    MacOS, Android, and Web) and employing policy optimization algorithms such as Group Relative Policy Optimization (GRPO)
+    to update the model, \name achieves superior performance using only 0.02\% of the data (3K vs. 13M) compared to previous
+    state-of-the-art methods like OS-Atlas across eight benchmarks spanning three different platforms (mobile, desktop, and
+    web). These results demonstrate the immense potential of reinforcement learning based on unified action space rule modeling
+    in improving the execution capabilities of LVLMs for real-world GUI agent tasks.
+  authors:
+  - Run Luo
+  - Lu Wang
+  - Wanwei He
+  - Longze Chen
+  - Jiaming Li
+  - Xiaobo Xia
+  arxiv_categories:
+  - cs.CV
+  - cs.CL
+  - cs.HC
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - agentic
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2502.19328
+  title: 'Agentic Reward Modeling: Integrating Human Preferences with Verifiable Correctness Signals for Reliable Reward Systems'
+  date: '2025-02-26'
+  updated: '2025-02-26'
+  url: https://arxiv.org/abs/2502.19328
+  abstract: 'Reward models (RMs) are crucial for the training and inference-time scaling up of large language models (LLMs).
+    However, existing reward models primarily focus on human preferences, neglecting verifiable correctness signals which
+    have shown strong potential in training LLMs. In this paper, we propose agentic reward modeling, a reward system that
+    combines reward models with verifiable correctness signals from different aspects to provide reliable rewards. We empirically
+    implement a reward agent, named RewardAgent, that combines human preference rewards with two verifiable signals: factuality
+    and instruction following, to provide more reliable rewards. We conduct comprehensive experiments on existing reward model
+    benchmarks and inference time best-of-n searches on real-world downstream tasks. RewardAgent significantly outperforms
+    vanilla reward models, demonstrating its effectiveness. We further construct training preference pairs using RewardAgent
+    and train an LLM with the DPO objective, achieving superior performance on various NLP benchmarks compared to conventional
+    reward models. Our codes are publicly released to facilitate further research (https://github.com/THU-KEG/Agentic-Reward-Modeling).'
+  authors:
+  - Hao Peng
+  - Yunjia Qi
+  - Xiaozhi Wang
+  - Zijun Yao
+  - Bin Xu
+  - Lei Hou
+  - Juanzi Li
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - preference-alignment
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.13957
+  title: Supervising the search process produces reliable and generalizable information-seeking agents
+  date: '2025-02-19'
+  updated: '2026-05-16'
+  url: https://arxiv.org/abs/2502.13957
+  abstract: Large language models (LLMs) are transforming web search by shifting from document ranking to synthesizing answers,
+    and are increasingly deployed as autonomous agentic search systems that iteratively interact with external knowledge sources.
+    Despite this progress, building effective search agents remains challenging because high-quality intermediate search steps
+    are difficult to generate. Previous approaches have primarily relied on outcome supervision, rewarding agents only for
+    producing correct final answers. This often leads to reward hacking and excessive dependence on parametric memory, limiting
+    generalization to out-of-domain tasks. To address these limitations, we introduce RAG-Gym, a framework that shifts supervision
+    from final answers to the search process itself. With RAG-Gym, we systematically investigate architecture design, parameter
+    optimization, and action evaluation, identifying reasoning reflection as a critical capability for search agents. Building
+    on this insight, we propose Re$^2$Search++, a process-supervised agent that achieves substantial improvements on multi-hop
+    information-seeking benchmarks, especially in out-of-domain settings. Performance gains are driven primarily by higher-quality
+    search queries rather than answer optimization alone, and the learned search critics transfer across models, including
+    proprietary LLMs. These findings show that supervising the search process produces more reliable and generalizable information-seeking
+    agents.
+  authors:
+  - Guangzhi Xiong
+  - Qiao Jin
+  - Xiao Wang
+  - Yin Fang
+  - Haolin Liu
+  - Yifan Yang
+  - Fangyuan Chen
+  - Zhixing Song
+  - Dengyu Wang
+  - Minjia Zhang
+  - Zhiyong Lu
+  - Aidong Zhang
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - multimodal
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.10458
+  title: 'I Think, Therefore I Diffuse: Enabling Multimodal In-Context Reasoning in Diffusion Models'
+  date: '2025-02-12'
+  updated: '2025-02-12'
+  url: https://arxiv.org/abs/2502.10458
+  abstract: 'This paper presents ThinkDiff, a novel alignment paradigm that empowers text-to-image diffusion models with multimodal
+    in-context understanding and reasoning capabilities by integrating the strengths of vision-language models (VLMs). Existing
+    multimodal diffusion finetuning methods largely focus on pixel-level reconstruction rather than in-context reasoning,
+    and are constrained by the complexity and limited availability of reasoning-based datasets. ThinkDiff addresses these
+    challenges by leveraging vision-language training as a proxy task, aligning VLMs with the decoder of an encoder-decoder
+    large language model (LLM) instead of a diffusion decoder. This proxy task builds on the observation that the $\textbf{LLM
+    decoder}$ shares the same input feature space with $\textbf{diffusion decoders}$ that use the corresponding $\textbf{LLM
+    encoder}$ for prompt embedding. As a result, aligning VLMs with diffusion decoders can be simplified through alignment
+    with the LLM decoder. Without complex training and datasets, ThinkDiff effectively unleashes understanding, reasoning,
+    and composing capabilities in diffusion models. Experiments demonstrate that ThinkDiff significantly improves accuracy
+    from 19.2% to 46.3% on the challenging CoBSAT benchmark for multimodal in-context reasoning generation, with only 5 hours
+    of training on 4 A100 GPUs. Additionally, ThinkDiff demonstrates exceptional performance in composing multiple images
+    and texts into logically coherent images. Project page: https://mizhenxing.github.io/ThinkDiff.'
+  authors:
+  - Zhenxing Mi
+  - Kuan-Chieh Wang
+  - Guocheng Qian
+  - Hanrong Ye
+  - Runtao Liu
+  - Sergey Tulyakov
+  - Kfir Aberman
+  - Dan Xu
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - generative-media
+  - multimodal
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.02584
+  title: 'QLASS: Boosting Language Agent Inference via Q-Guided Stepwise Search'
+  date: '2025-02-04'
+  updated: '2025-02-04'
+  url: https://arxiv.org/abs/2502.02584
+  abstract: Language agents have become a promising solution to complex interactive tasks. One of the key ingredients to the
+    success of language agents is the reward model on the trajectory of the agentic workflow, which provides valuable guidance
+    during training or inference. However, due to the lack of annotations of intermediate interactions, most existing works
+    use an outcome reward model to optimize policies across entire trajectories. This may lead to sub-optimal policies and
+    hinder the overall performance. To address this, we propose QLASS (Q-guided Language Agent Stepwise Search), to automatically
+    generate annotations by estimating Q-values in a stepwise manner for open language agents. By introducing a reasoning
+    tree and performing process reward modeling, QLASS provides effective intermediate guidance for each step. With the stepwise
+    guidance, we propose a Q-guided generation strategy to enable language agents to better adapt to long-term value, resulting
+    in significant performance improvement during model inference on complex interactive agent tasks. Notably, even with almost
+    half the annotated data, QLASS retains strong performance, demonstrating its efficiency in handling limited supervision.
+    We also empirically demonstrate that QLASS can lead to more effective decision making through qualitative analysis. We
+    will release our code and data.
+  authors:
+  - Zongyu Lin
+  - Yao Tang
+  - Xingcheng Yao
+  - Da Yin
+  - Ziniu Hu
+  - Yizhou Sun
+  - Kai-Wei Chang
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2501.05366
+  title: 'Search-o1: Agentic Search-Enhanced Large Reasoning Models'
+  date: '2025-01-09'
+  updated: '2025-01-09'
+  url: https://arxiv.org/abs/2501.05366
+  abstract: Large reasoning models (LRMs) like OpenAI-o1 have demonstrated impressive long stepwise reasoning capabilities
+    through large-scale reinforcement learning. However, their extended reasoning processes often suffer from knowledge insufficiency,
+    leading to frequent uncertainties and potential errors. To address this limitation, we introduce \textbf{Search-o1}, a
+    framework that enhances LRMs with an agentic retrieval-augmented generation (RAG) mechanism and a Reason-in-Documents
+    module for refining retrieved documents. Search-o1 integrates an agentic search workflow into the reasoning process, enabling
+    dynamic retrieval of external knowledge when LRMs encounter uncertain knowledge points. Additionally, due to the verbose
+    nature of retrieved documents, we design a separate Reason-in-Documents module to deeply analyze the retrieved information
+    before injecting it into the reasoning chain, minimizing noise and preserving coherent reasoning flow. Extensive experiments
+    on complex reasoning tasks in science, mathematics, and coding, as well as six open-domain QA benchmarks, demonstrate
+    the strong performance of Search-o1. This approach enhances the trustworthiness and applicability of LRMs in complex reasoning
+    tasks, paving the way for more reliable and versatile intelligent systems. The code is available at \url{https://github.com/sunnynexus/Search-o1}.
+  authors:
+  - Xiaoxi Li
+  - Guanting Dong
+  - Jiajie Jin
+  - Yuyao Zhang
+  - Yujia Zhou
+  - Yutao Zhu
+  - Peitian Zhang
+  - Zhicheng Dou
+  arxiv_categories:
+  - cs.AI
+  - cs.CL
+  - cs.IR
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2501.01904
+  title: 'Virgo: A Preliminary Exploration on Reproducing o1-like MLLM'
+  date: '2025-01-03'
+  updated: '2025-02-05'
+  url: https://arxiv.org/abs/2501.01904
+  abstract: Recently, slow-thinking reasoning systems, built upon large language models (LLMs), have garnered widespread attention
+    by scaling the thinking time during inference. There is also growing interest in adapting this capability to multimodal
+    large language models (MLLMs). Given that MLLMs handle more complex data semantics across different modalities, it is
+    intuitively more challenging to implement multimodal slow-thinking systems. To address this issue, in this paper, we explore
+    a straightforward approach by fine-tuning a capable MLLM with a small amount of textual long-form thought data, resulting
+    in a multimodal slow-thinking system, Virgo (Visual reasoning with long thought). We find that these long-form reasoning
+    processes, expressed in natural language, can be effectively transferred to MLLMs. Moreover, it seems that such textual
+    reasoning data can be even more effective than visual reasoning data in eliciting the slow-thinking capacities of MLLMs.
+    While this work is preliminary, it demonstrates that slow-thinking capacities are fundamentally associated with the language
+    model component, which can be transferred across modalities or domains. This finding can be leveraged to guide the development
+    of more powerful slow-thinking reasoning systems. We release our resources at https://github.com/RUCAIBox/Virgo.
+  authors:
+  - Yifan Du
+  - Zikang Liu
+  - Yifan Li
+  - Wayne Xin Zhao
+  - Yuqi Huo
+  - Bingning Wang
+  - Weipeng Chen
+  - Zheng Liu
+  - Zhongyuan Wang
+  - Ji-Rong Wen
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2412.20631
+  title: 'Slow Perception: Let''s Perceive Geometric Figures Step-by-step'
+  date: '2024-12-30'
+  updated: '2025-01-26'
+  url: https://arxiv.org/abs/2412.20631
+  abstract: 'Recently, "visual o1" began to enter people''s vision, with expectations that this slow-thinking design can solve
+    visual reasoning tasks, especially geometric math problems. However, the reality is that current LVLMs (Large Vision Language
+    Models) can hardly even accurately copy a geometric figure, let alone truly understand the complex inherent logic and
+    spatial relationships within geometric shapes. We believe accurate copying (strong perception) is the first step to visual
+    o1. Accordingly, we introduce the concept of "slow perception" (SP), which guides the model to gradually perceive basic
+    point-line combinations, as our humans, reconstruct complex geometric structures progressively. There are two-fold stages
+    in SP: a) perception decomposition. Perception is not instantaneous. In this stage, complex geometric figures are broken
+    down into basic simple units to unify geometry representation. b) perception flow, which acknowledges that accurately
+    tracing a line is not an easy task. This stage aims to avoid "long visual jumps" in regressing line segments by using
+    a proposed "perceptual ruler" to trace each line stroke-by-stroke. Surprisingly, such a human-like perception manner enjoys
+    an inference time scaling law -- the slower, the better. Researchers strive to speed up the model''s perception in the
+    past, but we slow it down again, allowing the model to read the image step-by-step and carefully.'
+  authors:
+  - Haoran Wei
+  - Youyang Yin
+  - Yumeng Li
+  - Jia Wang
+  - Liang Zhao
+  - Jianjian Sun
+  - Zheng Ge
+  - Xiangyu Zhang
+  - Daxin Jiang
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2412.17451
+  title: Diving into Self-Evolving Training for Multimodal Reasoning
+  date: '2024-12-23'
+  updated: '2025-06-06'
+  url: https://arxiv.org/abs/2412.17451
+  abstract: 'Self-evolving trainin--where models iteratively learn from their own outputs--has emerged as a key approach for
+    complex reasoning tasks, addressing the scarcity of high-quality chain-of-thought data. However, its effectiveness in
+    multimodal reasoning, a domain more intricate than text-only reasoning, remains underexplored, and the understanding of
+    critical factors in this training paradigm remains limited. Furthermore, a central challenge for this training method
+    is performance saturation, which impedes further improvements and scalability. Inspired by reinforcement learning (RL),
+    in this paper, we reframe self-evolving training for multimodal reasoning through the lens of RL, identifying three pivotal
+    factors: Training Method, Reward Model, and Prompt Variation. Through systematic analysis, we establish relatively optimal
+    design principles that significantly enhance multimodal reasoning capabilities. Moreover, delving deeper into training
+    dynamics, we uncover the roots of saturation and propose a new automatic balancing mechanism to mitigate this limitation.
+    Building on these insights, we propose M-STAR (Multimodal Self-evolving Training for Reasoning), a framework that achieves
+    consistent performance gains across models of varying sizes and diverse benchmarks. All resources are made publicly available
+    at https://mstar-lmm.github.io.'
+  authors:
+  - Wei Liu
+  - Junlong Li
+  - Xiwen Zhang
+  - Fan Zhou
+  - Yu Cheng
+  - Junxian He
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.CV
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - multimodal
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2412.03704
+  title: Scaling Inference-Time Search with Vision Value Model for Improved Visual Comprehension
+  date: '2024-12-04'
+  updated: '2025-06-30'
+  url: https://arxiv.org/abs/2412.03704
+  abstract: Despite significant advancements in vision-language models (VLMs), there lacks effective approaches to enhance
+    response quality by scaling inference-time computation. This capability is known to be a core step towards the self-improving
+    models in recent large language model studies. In this paper, we present Vision Value Model (VisVM) that can guide VLM
+    inference-time search to generate responses with better visual comprehension. Specifically, VisVM not only evaluates the
+    generated sentence quality in the current search step, but also anticipates the quality of subsequent sentences that may
+    result from the current step, thus providing a long-term value. In this way, VisVM steers VLMs away from generating sentences
+    prone to hallucinations or insufficient detail, thereby producing higher quality responses. Experimental results demonstrate
+    that VisVM-guided search significantly enhances VLMs' ability to generate descriptive captions with richer visual details
+    and fewer hallucinations, compared with greedy decoding and search methods with other visual reward signals. Furthermore,
+    we find that self-training the model with the VisVM-guided captions improve VLM's performance across a wide range of multimodal
+    benchmarks, indicating the potential for developing self-improving VLMs. Our value model and code are available at https://github.com/si0wang/VisVM.
+  authors:
+  - Xiyao Wang
+  - Zhengyuan Yang
+  - Linjie Li
+  - Hongjin Lu
+  - Yuancheng Xu
+  - Chung-Ching Lin
+  - Kevin Lin
+  - Furong Huang
+  - Lijuan Wang
+  arxiv_categories:
+  - cs.CV
+  - cs.CL
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - agentic
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2308.08998
+  title: Reinforced Self-Training (ReST) for Language Modeling
+  date: '2023-08-17'
+  updated: '2023-08-21'
+  url: https://arxiv.org/abs/2308.08998
+  abstract: Reinforcement learning from human feedback (RLHF) can improve the quality of large language model's (LLM) outputs
+    by aligning them with human preferences. We propose a simple algorithm for aligning LLMs with human preferences inspired
+    by growing batch reinforcement learning (RL), which we call Reinforced Self-Training (ReST). Given an initial LLM policy,
+    ReST produces a dataset by generating samples from the policy, which are then used to improve the LLM policy using offline
+    RL algorithms. ReST is more efficient than typical online RLHF methods because the training dataset is produced offline,
+    which allows data reuse. While ReST is a general approach applicable to all generative learning settings, we focus on
+    its application to machine translation. Our results show that ReST can substantially improve translation quality, as measured
+    by automated metrics and human evaluation on machine translation benchmarks in a compute and sample-efficient manner.
+  authors:
+  - Caglar Gulcehre
+  - Tom Le Paine
+  - Srivatsan Srinivasan
+  - Ksenia Konyushkova
+  - Lotte Weerts
+  - Abhishek Sharma
+  - Aditya Siddhant
+  - Alex Ahern
+  - Miaosen Wang
+  - Chenjie Gu
+  - Wolfgang Macherey
+  - Arnaud Doucet
+  - Orhan Firat
+  - Nando de Freitas
+  arxiv_categories:
+  - cs.CL
+  - cs.LG
+  source_signals:
+  - curated:on-policy-post-training
+  - curated:preference-learning
+  direction_hints:
+  - distillation
+  - preference-alignment
+  status: candidate
+  review_priority: 2
+  rule_score: 5
+  rule_reasons:
+  - curated-source:on-policy-post-training
+  - curated-source:preference-learning
+- id: arxiv:2607.04428
+  title: 'dOPSD: On-Policy Self-Distillation for Diffusion Language Models'
+  date: '2026-07-05'
+  updated: '2026-07-05'
+  url: https://arxiv.org/abs/2607.04428
+  abstract: 'Diffusion large language models (dLLMs) generate text by iteratively denoising a masked sequence, offering a
+    parallel alternative to autoregressive models, but eliciting strong reasoning through post-training remains difficult:
+    supervised fine-tuning is off-policy and suffers from exposure bias, while reinforcement learning gives only sparse, sequence-level
+    rewards and is hard to apply without tractable sequence likelihoods. On-policy self-distillation (OPSD) offers a promising
+    alternative, using one model as both student and teacher to provide dense, token-level, on-policy supervision, but its
+    effectiveness hinges on giving the teacher privileged information (PI) - typically an instance-specific ground-truth reference
+    unavailable at inference - so the student ends up distilling a weak PI-free consensus policy that yields little improvement
+    on dLLM reasoning. We introduce dOPSD, which instead derives the teacher''s privilege directly from the student''s own
+    denoising trajectory, evaluating masked positions using later, more-decoded steps of that same trajectory rather than
+    an external label, so the teacher''s advantage emerges from the model''s own decoding process; on Dream and LLaDA, dOPSD
+    improves both in-domain math reasoning and out-of-domain code generation, outperforming supervised and on-policy baselines.'
+  authors:
+  - Phuong Tuan Dat
+  - Qi Li
+  - Xinchao Wang
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.18195
+  title: 'Learning from the Self-future: On-policy Self-distillation for dLLMs'
+  date: '2026-06-16'
+  updated: '2026-06-25'
+  url: https://arxiv.org/abs/2606.18195
+  abstract: On-policy self-distillation (OPSD) has proven effective for post-training large language models (LLMs), yet its
+    application to diffusion LLMs (dLLMs) remains unexplored. Existing OPSD methods are inherently autoregressive-centric.
+    They inject privileged information via left-to-right prefix conditioning with token-level divergence supervision, a design
+    that fundamentally conflicts with the arbitraryorder generation of dLLMs. We introduce d-OPSD, the first OPSD framework
+    tailored for dLLMs. Our approach makes two core contributions. First, we reframe self-teacher construction by using self-generated
+    answers as suffix conditioning, enabling the student model to learn from "self future-experience" rather than privileged
+    prefixes. Second, we shift supervision from token-level to step-level, aligning training with the iterative denoising
+    process of dLLMs. Experiments across four reasoning benchmarks show that d-OPSD consistently outperforms RLVR and SFT
+    baselines with superior sample efficiency, requiring only around 10% of the optimization steps by RLVR and opening a promising
+    pathway for dLLM posttraining. The code is available at https://github.com/xingzhejun/d-OPSD.
+  authors:
+  - Yifu Luo
+  - Zeyu Chen
+  - Haoyu Wang
+  - Xinhao Hu
+  - Yuxuan Zhang
+  - Zhizhou Sha
+  - Shiwei Liu
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.23605
+  title: 'DiLaDiff: Distilled Latent-Augmented Diffusion for Language Modeling'
+  date: '2026-05-22'
+  updated: '2026-05-22'
+  url: https://arxiv.org/abs/2605.23605
+  abstract: 'Diffusion language models intrinsically fail to capture correlations between decoded tokens, which leads to a
+    harsh trade-off between sampling quality and throughput. To solve this issue, we propose DiLaDiff, a variant of masked
+    diffusion language models with three components: (1) a continuous latent space with semantic capabilities, learned by
+    an auto-encoder fine-tuned from an existing masked diffusion language model; (2) a latent diffusion model learning the
+    prior over the encoder distribution; (3) a consistency model distilling the learned prior into a few-step latent generative
+    model. We show that, even without distillation, our latent-guided diffusion model outperforms the masked diffusion baseline
+    while significantly accelerating inference. Consistency distillation further lowers the computational overhead of continuous
+    diffusion, such that the latent is generated in negligible time compared to discrete decoding.'
+  authors:
+  - Jean-Marie Lemercier
+  - Tomas Geffner
+  - Karsten Kreis
+  - Morteza Mardani
+  - Arash Vahdat
+  - Ante Jukić
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.21924
+  title: Visual-Advantage On-Policy Distillation for Vision-Language Models
+  date: '2026-05-21'
+  updated: '2026-05-21'
+  url: https://arxiv.org/abs/2605.21924
+  abstract: 'On-policy knowledge distillation has proven effective for language models, yet its application to vision-language
+    models (VLMs) remains underexplored. We observe that standard on-policy distillation can improve a student''s output quality
+    while failing to strengthen its reliance on visual input: on vision-critical tokens, the student''s predictions remain
+    largely unchanged whether or not fine-grained visual detail is present, even though the teacher''s predictions depend
+    heavily on it.To make this difference observable, we introduce visual advantage (VA), the token-level log-probability
+    difference when the teacher scores a student-generated rollout with versus without access to fine-grained visual detail.
+    VA is concentrated in a small minority of tokens, and these high-VA tokens are the ones that actually carry the visual
+    supervision signal. This motivates a distillation objective that treats them differently from language scaffolding, so
+    their contribution is not diluted by the abundant surrounding language tokens.We propose Visual-Advantage On-Policy Distillation
+    (VA-OPD), which uses VA at two granularities: rollout-level reweighting by trajectory-averaged VA, and token-level KL
+    averaged within high-VA and low-VA groups separately. We train on two math datasets (Geometry3K and ViRL39K) and evaluate
+    on eight benchmarks covering both mathematical reasoning and visual understanding, across three teacher sizes (4B, 8B,
+    and 32B) on the Qwen3-VL family. VA-OPD improves over standard on-policy distillation on every benchmark, with the gain
+    growing monotonically along both the teacher-size and data-scale axes, suggesting that these factors compound consistently.'
+  authors:
+  - Ruiqi Liu
+  - Xiaolei Lv
+  - Gengsheng Li
+  - Ximo Zhu
+  - Zhiheng Wang
+  - Zhengbo Zhang
+  - Junkai Chen
+  - Zhiheng Li
+  - Bo Li
+  - Jun Gao
+  - Shu Wu
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - distillation
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2605.21139
+  title: 'Distill to Think, Foresee to Act: Cognitive-Physical Reinforcement Learning for Autonomous Driving'
+  date: '2026-05-20'
+  updated: '2026-05-22'
+  url: https://arxiv.org/abs/2605.21139
+  abstract: 'Current end-to-end autonomous driving models are fundamentally constrained by the behavioral cloning ceiling
+    of imitation learning. While reinforcement learning offers a path to smarter autonomy, it demands two missing pieces of
+    infrastructure: (1) a cognitive foundation that understands traffic semantics and driving intent, and (2) a foresighted
+    physical environment that can anticipate the consequences of candidate actions. To this end, we propose CoPhy, a CognitivePhysical
+    reinforcement learning framework for autonomous driving. To distill to think, we distill VLM knowledge into the BEV encoder
+    and then discard the VLM entirely, retaining cognitive ability at zero inference cost while releasing the cognitive channel
+    as a pluggable interface for optional human language commands. To foresee to act, we build an auto-regressive BEV world
+    model that explicitly predicts future semantic maps conditioned on candidate actions, serving as an interpretable physical
+    sandbox from which safety metrics are directly derived. Built upon this dual infrastructure, we optimize the driving policy
+    via GRPO with a novel dual-reward mechanism: a physical reward derived from BEV rollouts enforces hard safety constraints,
+    while a cognitive reward from a language-aligned scorer ensures intent compliance. Extensive experiments demonstrate that
+    CoPhy not only achieves state-of-the-art results on NAVSIM v1 and v2 benchmarks, but also enables safer driving via cognitively
+    informed scene compliance and flexible intent control through user-defined language instructions.'
+  authors:
+  - Yang Wu
+  - Qiang Meng
+  - Zhaojiang Liu
+  - Youquan Liu
+  - Jian Yang
+  - Jin Xie
+  arxiv_categories:
+  - cs.CV
+  - cs.LG
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - distillation
+  - embodied-vla
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.20199
+  title: 'FlowLM: Few-Step Language Modeling via Diffusion-to-Flow Adaptation'
+  date: '2026-04-06'
+  updated: '2026-04-06'
+  url: https://arxiv.org/abs/2605.20199
+  abstract: 'We present FlowLM, a flow matching language model transformed from pre-trained diffusion language models via
+    efficient fine-tuning. By re-aligning the curved sampling trajectories of diffusion models into straight-line flows, FlowLM
+    enables high quality few-step generation that rivals or even outperforms the quality of 2,000-step diffusion sampling
+    with very few training epochs. Remarkably, finetuned FlowLM reaches performance saturation with only half as many training
+    epochs as training from scratch, both approaches greatly outperforming the original diffusion model, thereby validating
+    our method. Furthermore, we validate a more effective training objective for flow matching: predicting clean data to consistently
+    guide the sampling process towards the true data distribution. Empirical results demonstrate that our approach is highly
+    effective for high-quality, few-step text generation.'
+  authors:
+  - Runzhe Zhang
+  - Letian Chen
+  - Wenpeng Zhang
+  - Zhouhan Lin
+  - Peilin Zhao
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.18740
+  title: 'Vision-OPD: Learning to See Fine Details for Multimodal LLMs via On-Policy Self-Distillation'
+  date: '2026-05-18'
+  updated: '2026-06-02'
+  url: https://arxiv.org/abs/2605.18740
+  abstract: 'Multimodal Large Language Models (MLLMs) still struggle with fine-grained visual understanding, where answers
+    often depend on small but decisive evidence in the full image. We observe a regional-to-global perception gap: the same
+    MLLM answers fine-grained questions more accurately when conditioned on evidence-centered crops than on the corresponding
+    full images, suggesting that many failures stem from difficulty to focus on relevant evidence rather than insufficient
+    local recognition ability. Motivated by this observation, we propose Vision-OPD (Vision On-Policy Distillation), a regional-to-global
+    self-distillation framework that transfers the model''s own privileged regional perception to its full-image policy. Vision-OPD
+    instantiates two conditional policies from the same MLLM: a crop-conditioned teacher and a full-image-conditioned student.
+    The student generates on-policy rollouts, and Vision-OPD minimizes token-level divergence between the teacher and student
+    next-token distributions along these rollouts. This enables the model to internalize the benefit of visual zooming without
+    external teacher models, ground-truth labels, reward verifiers, or inference-time tool use. Experiments on multiple fine-grained
+    visual understanding benchmarks show that Vision-OPD models achieve competitive or superior performance against much larger
+    open-source, closed-source, and "Thinking-with-Images" agentic models. The code is available at https://github.com/VisionOPD/Vision-OPD'
+  authors:
+  - Qianhao Yuan
+  - Jie Lou
+  - Xing Yu
+  - Hongyu Lin
+  - Le Sun
+  - Xianpei Han
+  - Yaojie Lu
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  - cs.CL
+  - cs.LG
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - distillation
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2605.11854
+  title: 'Self-Distilled Trajectory-Aware Boltzmann Modeling: Bridging the Training-Inference Discrepancy in Diffusion Language
+    Models'
+  date: '2026-05-12'
+  updated: '2026-05-18'
+  url: https://arxiv.org/abs/2605.11854
+  abstract: 'Diffusion Language Models (DLMs) have recently emerged as a promising alternative to autoregressive language
+    models, offering stronger global awareness and highly parallel generation. However, post-training DLMs with standard Negative
+    Evidence Lower Bound (NELBO)-based supervised fine-tuning remains inefficient: training reconstructs randomly masked tokens
+    in a single step, whereas inference follows a confidence-guided, multi-step easy-to-hard denoising trajectory. Recent
+    trajectory-based self-distillation methods exploit such inference trajectories mainly for sampling-step compression and
+    acceleration, often improving decoding efficiency without substantially enhancing the model''s underlying capability,
+    and may even degrade performance under full diffusion decoding. In this work, we ask whether self-distilled trajectories
+    can be used not merely for faster inference, but for genuine knowledge acquisition. Although these trajectories lie on
+    the pretrained DLM''s own distributional manifold and thus offer a potentially lower optimization barrier, we find that
+    naively fine-tuning on them with standard NELBO objectives yields only marginal gains. To address this limitation, we
+    propose \textbf{T}rajectory-\textbf{A}ligned optimization via \textbf{Bo}ltzmann \textbf{M}odeling (\textbf{TABOM}), a
+    self-distilled trajectory-based post-training framework that aligns training with the easy-to-hard structure of inference.
+    TABOM models the inference unmasking preference as a Boltzmann distribution over predictive entropies and derives a tractable
+    pairwise ranking objective to align the model''s certainty ordering with the observed decoding trajectory. Empirically,
+    TABOM achieves substantial gains in new domains, expands the effective knowledge boundary of DLMs, and significantly mitig'
+  authors:
+  - Kecheng Chen
+  - Ziru Liu
+  - Xijia Tao
+  - Hui Liu
+  - Yibing Liu
+  - Xinyu Fu
+  - Shi Wu
+  - Suiyun Zhang
+  - Dandan Tu
+  - Lingpeng Kong
+  - Rui Liu
+  - Haoliang Li
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.10518
+  title: Infinite Mask Diffusion for Few-Step Distillation
+  date: '2026-05-11'
+  updated: '2026-05-11'
+  url: https://arxiv.org/abs/2605.10518
+  abstract: Masked Diffusion Models (MDMs) have emerged as a promising alternative to autoregressive models in language modeling,
+    offering the advantages of parallel decoding and bidirectional context processing within a simple yet effective framework.
+    Specifically, their explicit distinction between masked tokens and data underlies their simple framework and effective
+    conditional generation. However, MDMs typically require many sampling iterations due to factorization errors stemming
+    from simultaneous token updates. We observe that a theoretical lower bound of the factorization error exists, which standard
+    MDMs cannot reduce due to their use of a deterministic single-state mask. In this paper, we propose the Infinite Mask
+    Diffusion Model (IMDM), which introduces a stochastic infinite-state mask to mitigate the theoretical bound while directly
+    inheriting the benefits of MDMs, including the compatibility with pre-trained weights. We empirically demonstrate that
+    MDM fails to perform few-step generation even in a simple synthetic task due to the factorization error bound, whereas
+    IMDM can find an efficient solution for the same task. Finally, when equipped with appropriate distillation methods, IMDM
+    surpasses existing few-step distillation methods at small step counts on LM1B and OpenWebText. Code is available at https://Ugness.github.io/official_imdm.
+  authors:
+  - Jaehoon Yoo
+  - Wonjung Kim
+  - Chanhyuk Lee
+  - Seunghoon Hong
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.09536
+  title: 'TAD: Temporal-Aware Trajectory Self-Distillation for Fast and Accurate Diffusion LLM'
+  date: '2026-05-10'
+  updated: '2026-05-10'
+  url: https://arxiv.org/abs/2605.09536
+  abstract: 'Diffusion large language models (dLLMs) offer a promising paradigm for parallel text generation, but in practice
+    they face an accuracy-parallelism trade-off, where increasing tokens per forward (TPF) often degrades generation quality.
+    Existing acceleration methods often gain speed at the cost of accuracy. To address this limitation, we propose TAD, a
+    Temporal-Aware trajectory self-Distillation framework. During data construction, we condition a teacher model on both
+    the prompt and the ground-truth response to generate decoding trajectories, recording the intermediate masked states throughout
+    the process. Based on how many decoding steps remain before each masked token is revealed, we partition masked positions
+    into near and distant subsets. For near tokens, we train the student with a hard cross-entropy loss using the teacher
+    trajectory tokens as labels, encouraging confident predictions for tokens that are about to be decoded. For distant tokens,
+    we apply a soft KL divergence loss between the teacher and student token distributions, providing softer supervision and
+    preserving future planning knowledge. This temporal-aware partition naturally gives rise to two deployment configurations:
+    a Quality model that prioritizes accuracy and a Speed model that favors more aggressive acceleration. Experiments show
+    that TAD consistently improves the accuracy-parallelism trade-off. On LLaDA, it raises average accuracy from 46.2\% to
+    51.6\% with the Quality model and average AUP from 46.2 to 257.1 with the Speed model. Our code is available at: https://github.com/BHmingyang/TAD'
+  authors:
+  - Haoyang Zhou
+  - Li Kong
+  - Shijie Ren
+  - Xiting Wang
+  - Shuang Liang
+  - Guowei Wang
+  - Zhenxuan Pan
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.04470
+  title: 'CRAFT: Counterfactual-to-Interactive Reinforcement Fine-Tuning for Driving Policies'
+  date: '2026-05-06'
+  updated: '2026-05-06'
+  url: https://arxiv.org/abs/2605.04470
+  abstract: 'Open-loop imitation learning has advanced modern autonomous driving policy architectures, but closed-loop deployment
+    remains vulnerable to policy-induced distribution shift. Existing post-training paradigms exhibit fundamental trade-offs:
+    closed-loop RL fine-tuning provides grounded feedback from executed actions but is constrained by the sparsity of informative
+    events, whereas counterfactual fine-tuning provides dense supervision over candidate futures but inherits bias from imperfect
+    future estimates. We introduce Counterfactual-to-Interactive Reinforcement Fine-Tuning (CRAFT), an on-policy framework
+    that formulates closed-loop post-training as proxy-residual optimization. CRAFT uses group-normalized counterfactual advantages
+    as a dense proxy for real closed-loop advantages and aligns this proxy with the closed-loop world through grounded residual
+    correction from interaction-critical events. To stabilize adaptation, CRAFT regularizes the online policy toward an EMA
+    teacher via asymmetric KL self-distillation. Theoretically, CRAFT decomposes the real closed-loop policy gradient into
+    proxy and residual terms under the same visited-state distribution, reducing residual variance with an aligned proxy while
+    mitigating proxy bias through grounded residual approximation. Empirically, CRAFT achieves the strongest closed-loop gains
+    on Bench2Drive across hierarchical planning, vision-language-action, and vocabulary-scoring architectures. Ablations,
+    scaling behavior, stability analyses, and transfer results further validate the complementary roles of dense counterfactual
+    proxy and grounded residual correction. Project page: https://currychen77.github.io/CRAFT.'
+  authors:
+  - Keyu Chen
+  - Nanfei Ye
+  - Yida Wang
+  - Wenchao Sun
+  - Danqi Zhao
+  - Hao Cheng
+  - Sifa Zheng
+  arxiv_categories:
+  - cs.LG
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - distillation
+  - reinforcement-learning
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.03677
+  title: 'Uni-OPD: Unifying On-Policy Distillation with a Dual-Perspective Recipe'
+  date: '2026-05-05'
+  updated: '2026-07-06'
+  url: https://arxiv.org/abs/2605.03677
+  abstract: 'On-policy distillation (OPD) has recently emerged as an effective post-training paradigm for consolidating the
+    capabilities of specialized expert models into a single student model. Despite its empirical success, the conditions under
+    which OPD yields reliable improvement remain poorly understood. In this work, we identify two fundamental bottlenecks
+    that limit effective OPD: insufficient exploration of informative states and unreliable teacher supervision for student
+    rollouts. Building on this insight, we propose Uni-OPD, a unified OPD framework that generalizes across Large Language
+    Models (LLMs) and Multimodal Large Language Models (MLLMs), centered on a dual-perspective optimization strategy. Specifically,
+    from the student''s perspective, we adopt two data balancing strategies to promote exploration of informative student-generated
+    states during training. From the teacher''s perspective, we show that reliable supervision hinges on whether aggregated
+    token-level guidance remains order-consistent with the outcome reward. To this end, we develop an outcome-guided margin
+    calibration mechanism to restore order consistency between correct and incorrect trajectories. We conduct extensive experiments
+    on 5 domains and 16 benchmarks covering diverse settings, including single-teacher and multi-teacher distillation across
+    LLMs and MLLMs, strong-to-weak distillation, and cross-modal distillation. Our results verify the effectiveness and versatility
+    of Uni-OPD and provide practical insights into reliable OPD.'
+  authors:
+  - Wenjin Hou
+  - Shangpin Peng
+  - Weinong Wang
+  - Zheng Ruan
+  - Yue Zhang
+  - Zhenglin Zhou
+  - Mingqi Gao
+  - Yifei Chen
+  - Kaiqi Wang
+  - Hongming Yang
+  - Chengquan Zhang
+  - Zhuotao Tian
+  - Han Hu
+  - Yi Yang
+  - Fei Wu
+  - Hehe Fan
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - distillation
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2605.00161
+  title: Consistent Diffusion Language Models
+  date: '2026-04-30'
+  updated: '2026-05-30'
+  url: https://arxiv.org/abs/2605.00161
+  abstract: Diffusion language models (DLMs) are an attractive alternative to autoregressive models because they promise sublinear-time,
+    parallel generation, yet practical gains remain elusive as high-quality samples still demand hundreds of refinement steps.
+    In continuous domains, consistency training along the probability-flow ODE is a popular recipe to accelerate diffusion.
+    For discrete diffusion, no analogous sample-space ODE exists, making direct adaptation ill-defined. We argue that the
+    right discrete substitute is the exact posterior bridge, the closed-form conditional law linking any two noise levels,
+    which is available for broad corruptions including masked and uniform diffusion. Building on this observation, we introduce
+    Multi-Path Discrete Consistency (MPDC), a new principle that trains a denoiser to be path-invariant in expectation across
+    these stochastic bridges, and instantiate it as the Consistent Diffusion Language Model (CDLM), a single-stage training
+    framework that does not require an already trained teacher model. Our CDLM objective recovers masked diffusion, continuous
+    consistency models, and progressive or discrete distillation as analytic limits or empirical approximations of one common
+    view. Empirically, CDLM establishes a new state of the art on both conditional and unconditional text-generation, consistently
+    outperforming strong base discrete diffusion models and often even multi-stage distilled baselines across sampling budgets,
+    with the largest gains in the few-step regime. Together, these results position CDLM as a principled and scalable foundation
+    for the next generation of fast, high-fidelity discrete generative modeling.
+  authors:
+  - Hasan Amin
+  - Yuan Gao
+  - Yaser Souri
+  - Subhojit Som
+  - Ming Yin
+  - Rajiv Khanna
+  - Xia Song
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2604.26951
+  title: 'Turning the TIDE: Cross-Architecture Distillation for Diffusion Large Language Models'
+  date: '2026-04-29'
+  updated: '2026-04-29'
+  url: https://arxiv.org/abs/2604.26951
+  abstract: 'Diffusion large language models (dLLMs) offer parallel decoding and bidirectional context, but state-of-the-art
+    dLLMs require billions of parameters for competitive performance. While existing distillation methods for dLLMs reduce
+    inference steps within a single architecture, none address cross-architecture knowledge transfer, in which the teacher
+    and student differ in architecture, attention mechanism, and tokenizer. We present TIDE, the first framework for cross-architecture
+    dLLM distillation, comprising three modular components: (1) TIDAL, which jointly modulates distillation strength across
+    training progress and diffusion timestep to account for the teacher''s noise-dependent reliability; (2) CompDemo, which
+    enriches the teacher''s context via complementary mask splitting to improve predictions under heavy masking; and (3) Reverse
+    CALM, a cross-tokenizer objective that inverts chunk-level likelihood matching, yielding bounded gradients and dual-end
+    noise filtering. Distilling 8B dense and 16B MoE teachers into a 0.6B student via two heterogeneous pipelines outperforms
+    the baseline by an average of 1.53 points across eight benchmarks, yielding notable gains in code generation, where HumanEval
+    scores reach 48.78 compared to 32.3 for the AR baseline.'
+  authors:
+  - Gongbo Zhang
+  - Wen Wang
+  - Ye Tian
+  - Li Yuan
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2603.24596
+  title: 'X-OPD: Cross-Modal On-Policy Distillation for Capability Alignment in Speech LLMs'
+  date: '2026-03-06'
+  updated: '2026-06-12'
+  url: https://arxiv.org/abs/2603.24596
+  abstract: While the shift from cascaded dialogue systems to end-to-end (E2E) speech Large Language Models (LLMs) improves
+    latency and paralinguistic modeling, E2E models often exhibit a significant performance degradation compared to their
+    text-based counterparts. The standard Supervised Fine-Tuning (SFT) and Reinforcement Learning (RL) training methods fail
+    to close this gap. To address this, we propose X-OPD, a novel Cross-Modal On-Policy Distillation framework designed to
+    systematically align the capabilities of Speech LLMs to their text-based counterparts. X-OPD enables the Speech LLM to
+    explore its own distribution via on-policy rollouts, where a text-based teacher model evaluates these trajectories and
+    provides token-level feedback, effectively distilling teacher's capabilities into student's multi-modal representations.
+    Extensive experiments across multiple benchmarks demonstrate that X-OPD significantly narrows the gap in complex tasks
+    while preserving the model's inherent capabilities.
+  authors:
+  - Di Cao
+  - Dongjie Fu
+  - Hai Yu
+  - Siqi Zheng
+  - Xu Tan
+  - Tao Jin
+  arxiv_categories:
+  - eess.AS
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - distillation
+  - multimodal
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2607.08072
+  title: Post-Training in End-to-End Autonomous Driving
+  date: '2026-07-09'
+  updated: '2026-07-13'
+  url: https://arxiv.org/abs/2607.08072
+  abstract: End-to-end models that map multimodal inputs directly to future trajectories/maneuvers have emerged as an increasingly
+    prominent research paradigm in autonomous driving. This class of models includes both Vision-Language-Action models and
+    trajectory-generative planners. Unlike classic machine learning applications, autonomous vehicles operate in safety-critical
+    and interaction-intensive environments where traditional open-loop imitation of expert demonstrations is not sufficient
+    to ensure reliability. In particular, small execution errors can accumulate over time, while recovery behaviors are scarce
+    in training data. In addition, long-horizon objectives such as safety and driving comfort are not captured by pointwise
+    labels either. These limitations have motivated a shift toward post-training techniques, which further refine driving
+    policies beyond pure imitation. This survey presents a unified view of post-training for autonomous driving by defining
+    its scope and organizing the existing literature into four major families based on the form of supervision they use. For
+    each family, we discuss its capabilities, limitations, and open challenges. We aim to facilitate a systematic understanding
+    of this emerging area and stimulate future research on reliable and efficient post-training for autonomous driving.A collection
+    of related papers is available at https://github.com/RYNing/Awesome-Post-Training-In-Autonomous-Driving-Papers.
+  authors:
+  - Ruining Yang
+  - Muxing Wang
+  - Yixiao Chen
+  - Tongfei Guo
+  - Yi Xu
+  - Can Cui
+  - Zichong Yang
+  - Yitian Zhang
+  - Ziran Wang
+  - Yun Fu
+  - Lili Su
+  arxiv_categories:
+  - cs.CV
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2606.03159
+  title: 'NVIDIA OmniDreams: Real-Time Generative World Model for Closed-Loop Autonomous Vehicle Simulation'
+  date: '2026-06-02'
+  updated: '2026-07-23'
+  url: https://arxiv.org/abs/2606.03159
+  abstract: As autonomous vehicle capabilities advance, the safe evaluation of driving policies in long-tail scenarios remains
+    a critical bottleneck. In closed-loop simulation, the driving policy model actively interacts with the environment, where
+    its actions dynamically update the simulator state and directly influence the next set of generated sensor observations.
+    While recent reconstruction-based neural simulators offer photorealism, they are fundamentally constrained by their initial
+    captured data and struggle to generalize to highly dynamic or novel scenes. To overcome these limitations, we introduce
+    OmniDreams, a foundation generative world model mid- and post-trained from the Cosmos diffusion model to autoregressively
+    generate action-conditioned videos in real time. By leveraging the rich visual priors of Cosmos and mid- and post-training
+    on 21k hours of driving scenarios, OmniDreams synthesizes complex, unobserved phenomena that are hard for traditional
+    simulators to capture, such as extreme weather and unpredictable dynamic agent behaviors. Crucially, it autoregressively
+    conditions its photorealistic sensor generation on past frames, the current simulator state, and immediate driving actions.
+    Deployed in a closed-loop system with the Alpamayo 1 policy model and AlpaSim orchestrator, OmniDreams acts as a highly
+    responsive, reactive environment, providing a scalable and comprehensive solution for training and evaluating next-generation
+    autonomous driving policies. We additionally show preliminary results indicating that a world-action model (WAM) post-trained
+    from OmniDreams achieves strong performance on the Physical AI Autonomous Vehicles NuRec dataset, surpassing the VLA-based
+    Alpamayo 1.5 research policy model while using only 1/5 the total parameters. These results hig
+  authors:
+  - ' NVIDIA'
+  - ' :'
+  - Aarti Basant
+  - Amlan Kar
+  - Despoina Paschalidou
+  - Fangyin Wei
+  - Francesco Ferroni
+  - Guillermo Garcia Cobo
+  - Haithem Turki
+  - Huan Ling
+  - Jaewoo Seo
+  - James Lucas
+  - Jay Zhangjie Wu
+  - Jialiang Wang
+  - Jonathan Lorraine
+  - Jun Gao
+  - Kai He
+  - Katarina Tothova
+  - Kevin Xie
+  - Michał Tyszkiewicz
+  - Qi Wu
+  - Riccardo de Lutio
+  - Ruilong Li
+  - Sanja Fidler
+  - Seung Wook Kim
+  - Tianchang Shen
+  - Tianshi Cao
+  - Tobias Pfaff
+  - William Lew
+  - Xindi Wu
+  - Xuanchi Ren
+  - Yifan Lu
+  - Yuxuan Zhang
+  - Zan Gojcic
+  - Zian Wang
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2606.00519
+  title: 'DriveAnchor: Progressive Anchor-based Flow Learning for Autonomous Driving Planning'
+  date: '2026-05-30'
+  updated: '2026-05-30'
+  url: https://arxiv.org/abs/2606.00519
+  abstract: 'We present DriveAnchor, a three-stage framework for autonomous driving planning that achieves behavioral diversity,
+    controllability, and safety in a composable pipeline. Demonstration Flow Pretraining replaces the unstructured Gaussian
+    prior with a vocabulary of 2,398 trajectory shapes constructed by farthest-point sampling, structurally grounding behavioral
+    diversity in vocabulary coverage. Guided Flow Post-training jointly post-trains an Energy Field module with flow matching
+    (FM), conditioning the Energy Field on static road geometry alone, to relocate anchors toward user-specified corridor
+    polygons before flow generation, adding controllability without differentiable guidance; after Stage 2, new corridor presets
+    require only Energy Field updates, not FM retraining. Reward-Refined Flow Fine-tuning applies zeroth-order reinforcement
+    learning to align each anchor''s output with collision-avoidance objectives: because the flow-matching model is a deterministic
+    feedforward network in single-step mode, each anchor uniquely determines the output trajectory, reducing reward optimization
+    to a direction search in anchor space without log-likelihood computation or ODE-to-SDE conversion. Evaluated on approximately
+    2 million held-out driving scenarios, DriveAnchor reduces near-range collision rates by 89% and improves mean reward by
+    32% without degradation in imitation accuracy, with 2.06 ms inference on NVIDIA Drive Orin. DriveAnchor has been validated
+    through real-world vehicle testing, confirming its practicality for production deployment.'
+  authors:
+  - Limin Yan
+  - Haoyun Tang
+  - Yutao Qiu
+  - Hongqing Liu
+  - Haoyu Xu
+  arxiv_categories:
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.31572
+  title: 'nuReasoning: A Reasoning-Centric Dataset and Benchmark for Long-Tail Autonomous Driving'
+  date: '2026-05-29'
+  updated: '2026-05-29'
+  url: https://arxiv.org/abs/2605.31572
+  abstract: Reasoning is essential for autonomous driving (AD) in long-tail scenarios, where vehicles must apply commonsense
+    knowledge, understand spatial relations, infer agent interactions, and make safe decisions. However, existing AD datasets
+    and benchmarks mainly target perception, prediction, or planning, and provide limited supervision for reasoning over realistic
+    long-tail driving scenes. We introduce nuReasoning, a large-scale real-world dataset and benchmark for reasoning-centric
+    AD. Following the lineage of nuScenes and nuPlan, nuReasoning advances real-world AD datasets and benchmarks toward reasoning
+    in long-tail driving scenarios. The dataset contains 20,000 clips, each 20 seconds long, collected across multiple cities,
+    with synchronized multi-camera images, LiDAR data, HD maps, object annotations, and human-verified reasoning annotations
+    spanning Spatial Reasoning, Decision Reasoning, and Counterfactual Reasoning. Unlike prior datasets that focus primarily
+    on visual question answering, nuReasoning supports both reasoning evaluation and planning evaluation, enabling a direct
+    study of how reasoning supervision affects driving performance. Experiments show that fine-tuning VLMs on nuReasoning
+    substantially improves driving-specific question answering, while incorporating reasoning supervision into VLA training
+    improves planning performance even when textual reasoning outputs are disabled at inference time. These results establish
+    nuReasoning as a foundation for evaluating and improving robust, interpretable, reasoning-driven AD systems in realistic
+    long-tail settings.
+  authors:
+  - Zhiyu Huang
+  - Johnson Liu
+  - Rui Song
+  - Zewei Zhou
+  - Ruining Yang
+  - Yun Zhang
+  - Tianhui Cai
+  - Hanyin Zhang
+  - Mingxuan Gao
+  - Valeria Xu
+  - Jiali Chen
+  - Yishan Shen
+  - Yiluan Guo
+  - ' Tony'
+  - ' Qi'
+  - Jiaqi Ma
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.31256
+  title: 'Before Parc Fermé: RL-Time Pruning for Efficient Embodied LLMs in Autonomous Driving'
+  date: '2026-05-29'
+  updated: '2026-05-29'
+  url: https://arxiv.org/abs/2605.31256
+  abstract: 'Embodied Large Language Models (LLMs) are increasingly used as reasoning modules in robotic control pipelines
+    to improve human-robot interaction, but their memory and generation latency make real-time deployment difficult. Pruning
+    can reduce these costs, but for controllers that undergo multiple pre- and post-training phases, the crucial question
+    is not only how much to prune, but when pruning should occur. In this work, we propose Before Parc Fermé (BPF), a pruning
+    strategy performed during RL that compresses embodied LLM controllers while they are still being optimized for closed-loop
+    behavior. This allows pruning decisions to account for the task-specific supervision and closed-loop feedback that shape
+    the final controller. We propose two variants: BPF-RL, which performs iterative pruning during RL by removing part of
+    the model at predefined training intervals, and BPF-SFT/RL, which first prunes part of the model structure during SFT
+    and then further compresses it during RL using the same iterative strategy as BPF-RL until the target pruning ratio is
+    reached. We evaluate BPF on RobotxR1, an LLM-based autonomous-driving control pipeline, using an established LLM pruning
+    framework (LLM-Pruner), and compare it against post-training pruning, post-training pruning with RL recovery, SFT-stage
+    pruning, and smaller dense models from the same family. Our results show that BPF provides the best task-performance vs.
+    memory and throughput trade-off among the considered pruning strategies. When compressing the larger RobotxR1 models,
+    BPF-SFT/RL achieves a $1.69\times$ better size-end-to-end performance trade-off than directly selecting a smaller dense
+    model from the same family, measured as removed parameters per lost percentage point of control adaptability. On the Jetson
+    AGX Or'
+  authors:
+  - Luca Benfenati
+  - Ali Azimi
+  - Matteo Risso
+  - Fabio Carapellese
+  - Daniele Jahier Pagliari
+  - Alessio Burrello
+  arxiv_categories:
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.28583
+  title: 'SARAD: LLM-Based Safety-Aware Hybrid Reinforcement Learning with Collision Prediction for Autonomous Driving'
+  date: '2026-05-27'
+  updated: '2026-05-27'
+  url: https://arxiv.org/abs/2605.28583
+  abstract: Ensuring both safety and efficiency in decision-making for autonomous driving systems remains a fundamental challenge.
+    Traditional Deep Reinforcement Learning (DRL) suffers from unsafe random exploration and slow convergence, while Large
+    Language Models (LLMs) demonstrate inherent latency in real-time inference operations. To address these limitations, this
+    paper proposes SARAD, a novel safety-aware hybrid framework that synergizes LLMs and DRL for autonomous driving. SARAD
+    substitutes the random exploration of DRL with Retrieval-Augmented Generation (RAG)-enhanced, LLM-guided decisions sourced
+    from a dynamic expert knowledge repository. An attention discriminator is proposed to integrate the prior knowledge of
+    LLMs into DRL policy optimization. A collision predictor module, fine-tuned with historical collision data, is further
+    designed to improve vehicle safety. Extensive experiments show that SARAD achieves significant performance improvements
+    in the Highway-Env simulator, validating the effectiveness of the proposed model in autonomous driving.
+  authors:
+  - Kangyu Wu
+  - Peng Cui
+  - Guoxi Chen
+  - Ya Zhang
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  - cs.LG
+  - eess.SY
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.23163
+  title: 'Fast-dDrive: Efficient Block-Diffusion VLM for Autonomous Driving'
+  date: '2026-05-22'
+  updated: '2026-05-25'
+  url: https://arxiv.org/abs/2605.23163
+  abstract: 'End-to-end autonomous driving via Vision-Language-Action (VLA) models demands a precarious balance between high-fidelity
+    trajectory planning and efficient inference. Existing paradigms typically fall short: autoregressive (AR) VLAs are memory-bandwidth-bound
+    on edge hardware and prone to exposure-bias drift, while full-sequence diffusion models preclude KV-cache reuse and suffer
+    from "logical leakage" that violates the fundamental perceive-then-plan causality. We present Fast-dDrive, a block-diffusion
+    VLA that performs bidirectional refinement within semantic units while enforcing strict causal ordering across them. Leveraging
+    the observation that driving VLAs often emit structured JSON-like outputs, Fast-dDrive freezes structural tokens into
+    a section scaffold and employs a section-aware training recipe that prioritizes safety-critical planning. We further introduce
+    Scaffold Speculative Decoding to achieve AR-equivalent quality at significantly higher throughput. Finally, we propose
+    a low-overhead test-time scaling scheme: by forking $N$ stochastic trajectory rollouts from a single shared-prefix KV
+    cache and averaging them, we effectively suppress prediction variance at a fractional computational cost. Empirical results
+    demonstrate that Fast-dDrive redefines the speed-accuracy frontier for driving agents. On the WOD-E2E test set, Fast-dDrive
+    achieves SOTA ADE@3s and ADE@5s, alongside the highest RFS among diffusion-based VLAs; on nuScenes, it reduces average
+    L2 error to $0.32$m (a $22\%$ improvement). When integrated with SGLang, our framework delivers $12\times$ throughput
+    speedup over the AR baseline, narrowing the gap between high-capacity VLAs and the efficiency demands of real-time on-vehicle
+    deployment.'
+  authors:
+  - Kewei Zhang
+  - Jin Wang
+  - Sensen Gao
+  - Chengyue Wu
+  - Yulong Cao
+  - Songyang Han
+  - Boris Ivanovic
+  - Langechuan Liu
+  - Marco Pavone
+  - Song Han
+  - Daquan Zhou
+  - Enze Xie
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - generative-media
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.20082
+  title: 'VL-DPO: Vision-Language-Guided Finetuning for Preference-Aligned Autonomous Driving'
+  date: '2026-05-19'
+  updated: '2026-05-19'
+  url: https://arxiv.org/abs/2605.20082
+  abstract: The rapid growth of autonomous driving datasets has enabled the scaling of powerful motion forecasting models.
+    While large-scale pretraining provides strong performance, the standard imitation objective may not fully capture the
+    complex nuances of human driving preferences. Meanwhile, recent advances in vision-language models (VLMs) have demonstrated
+    impressive reasoning and commonsense understanding. Building on these capabilities, this paper presents VL-DPO, a vision-language-guided
+    framework that aligns ego-vehicle motion forecasting models with human preferences. Our approach leverages a VLM as a
+    zero-shot reasoner to automatically generate preference pairs from a pretrained model's rollouts, which are then used
+    to finetune the model via Direct Preference Optimization (DPO). We finetune our models on the Waymo Open End-to-End Driving
+    Dataset (WOD-E2E) and evaluate performance against held-out human preference annotations using rater feedback score (RFS)
+    and average displacement error (ADE). Our experiments confirm that the VLM's trajectory selection is a high-quality proxy
+    for human preference. Our final model, VL-DPO, yields an 11.94% increase in RFS and a 10.01% reduction in ADE over the
+    pretrained model.
+  authors:
+  - Zhefan Xu
+  - Ghassen Jerfel
+  - Marina Haliem
+  - Qi Zhao
+  - Jeonhyung Kang
+  - Khaled S. Refaat
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.19524
+  title: 'SafeAlign-VLA: A Negative-Enhanced Safe Alignment Framework for Risk-Aware Autonomous Driving'
+  date: '2026-05-19'
+  updated: '2026-05-19'
+  url: https://arxiv.org/abs/2605.19524
+  abstract: 'End-to-end autonomous driving systems excel in common scenarios but struggle with safety-critical long-tail cases.
+    Vision-Language-Action (VLA) models are promising due to their strong reasoning capabilities. However, most VLA-based
+    approaches rely on positive expert demonstrations, rarely exploiting negative samples, leading to insufficient understanding
+    of risky behaviors and safety boundaries. To address this limitation, we propose SafeAlign-VLA, a unified negative-enhanced
+    safe alignment framework that incorporates negative data into supervised learning and reinforcement learning. First, we
+    develop a counterfactual safety pairing paradigm to generate structured safety labels and counterfactual positive trajectories
+    from risky scenarios via counterfactual reasoning. Then, a two-stage training strategy is adopted: negative-enhanced supervised
+    fine-tuning for failure feedback and trajectory correction, followed by anchor-based group relative policy optimization
+    that uses positive and negative trajectories as contrastive anchors to steer sampling and penalize high-risk behaviors
+    via group-relative advantages. Experiments on NAVSIM and DeepAccident validate the proposed framework. SafeAlign-VLA achieves
+    89.1 PDMS on the NAVSIM v1 testset, improving over the baseline without negative data by 1.3%. On DeepAccident, it reduces
+    the collision rate to 3.36%, while achieving 84.2% language accuracy and 85.8% risk prediction accuracy. These results
+    demonstrate the effectiveness of the proposed negative-enhanced safe alignment framework for safe and robust autonomous
+    driving.'
+  authors:
+  - Kefei Tian
+  - Yuansheng Lian
+  - Kai Yang
+  - Xiangdong Chen
+  - Shen Li
+  arxiv_categories:
+  - cs.RO
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.10744
+  title: 'C-CoT: Counterfactual Chain-of-Thought with Vision-Language Models for Safe Autonomous Driving'
+  date: '2026-05-11'
+  updated: '2026-05-11'
+  url: https://arxiv.org/abs/2605.10744
+  abstract: 'Safety-critical planning in complex environments, particularly at urban intersections, remains a fundamental
+    challenge for autonomous driving. Existing methods, whether rule-based or data-driven, frequently struggle to capture
+    complex scene semantics, infer potential risks, and make reliable decisions in rare, high-risk situations. While vision-language
+    models (VLMs) offer promising approaches for safe decision-making in these environments, most current approaches lack
+    reflective and causal reasoning, thereby limiting their overall robustness. To address this, we propose a counterfactual
+    chain-of-thought (C-CoT) framework that leverages VLMs to decompose driving decisions into five sequential stages: scene
+    description, critical object identification, risk prediction, counterfactual risk reasoning, and final action planning.
+    Within the counterfactual reasoning stage, we introduce a structured meta-action evaluation tree to explicitly assess
+    the potential consequences of alternative action combinations. This self-reflective reasoning establishes causal links
+    between action choices and safety outcomes, improving robustness in long-tail and out-of-distribution scenarios. To validate
+    our approach, we construct the DeepAccident-CCoT dataset based on the DeepAccident benchmark and fine-tune a Qwen2.5-VL
+    (7B) model using low-rank adaptation. Our model achieves a risk prediction recall of 81.9%, reduces the collision rate
+    to 3.52%, and lowers L2 error to 1.98 m. Ablation studies further confirm the critical role of counterfactual reasoning
+    and the meta-action evaluation tree in enhancing safety and interpretability.'
+  authors:
+  - Kefei Tian
+  - Yuansheng Lian
+  - Kai Yang
+  - Xiangdong Chen
+  - Shen Li
+  arxiv_categories:
+  - cs.CV
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2604.19710
+  title: 'SpanVLA: Efficient Action Bridging and Learning from Negative-Recovery Samples for Vision-Language-Action Model'
+  date: '2026-04-21'
+  updated: '2026-04-21'
+  url: https://arxiv.org/abs/2604.19710
+  abstract: Vision-Language-Action (VLA) models offer a promising autonomous driving paradigm for leveraging world knowledge
+    and reasoning capabilities, especially in long-tail scenarios. However, existing VLA models often struggle with the high
+    latency in action generation using an autoregressive generation framework and exhibit limited robustness. In this paper,
+    we propose SpanVLA, a novel end-to-end autonomous driving framework, integrating an autoregressive reasoning and a flow-matching
+    action expert. First, SpanVLA introduces an efficient bridge to leverage the vision and reasoning guidance of VLM to efficiently
+    plan future trajectories using a flow-matching policy conditioned on historical trajectory initialization, which significantly
+    reduces inference time. Second, to further improve the performance and robustness of the SpanVLA model, we propose a GRPO-based
+    post-training method to enable the VLA model not only to learn from positive driving samples but also to learn how to
+    avoid the typical negative behaviors and learn recovery behaviors. We further introduce mReasoning, a new real-world driving
+    reasoning dataset, focusing on complex, reasoning-demanding scenarios and negative-recovery samples. Extensive experiments
+    on the NAVSIM (v1 and v2) demonstrate the competitive performance of the SpanVLA model. Additionally, the qualitative
+    results across diverse scenarios highlight the planning performance and robustness of our model.
+  authors:
+  - Zewei Zhou
+  - Ruining Yang
+  - ' Xuewei'
+  - ' Qi'
+  - Yiluan Guo
+  - Sherry X. Chen
+  - Tao Feng
+  - Kateryna Pistunova
+  - Yishan Shen
+  - Lili Su
+  - Jiaqi Ma
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2604.12656
+  title: 'FeaXDrive: Feasibility-aware Trajectory-Centric Diffusion Planning for End-to-End Autonomous Driving'
+  date: '2026-04-14'
+  updated: '2026-04-30'
+  url: https://arxiv.org/abs/2604.12656
+  abstract: End-to-end diffusion planning has shown strong potential for autonomous driving, but the physical feasibility
+    of generated trajectories remains insufficiently addressed. In particular, generated trajectories may exhibit local geometric
+    irregularities, violate trajectory-level kinematic constraints, or deviate from the drivable area, indicating that the
+    commonly used noise-centric formulation in diffusion planning is not yet well aligned with the trajectory space where
+    feasibility is more naturally characterized. To address this issue, we propose FeaXDrive, a feasibility-aware trajectory-centric
+    diffusion planning method for end-to-end autonomous driving. The core idea is to treat the clean trajectory as the unified
+    object for feasibility-aware modeling throughout the diffusion process. Built on this trajectory-centric formulation,
+    FeaXDrive integrates adaptive curvature-constrained training to improve intrinsic geometric and kinematic feasibility,
+    drivable-area guidance within reverse diffusion sampling to enhance consistency with the drivable area, and feasibility-aware
+    GRPO post-training to further improve planning performance while balancing trajectory-space feasibility. Experiments on
+    the NAVSIM benchmark show that FeaXDrive achieves strong closed-loop planning performance while substantially improving
+    trajectory-space feasibility. These findings highlight the importance of explicitly modeling trajectory-space feasibility
+    in end-to-end diffusion planning and provide a step toward more reliable and physically grounded autonomous driving planners.
+  authors:
+  - Baoyun Wang
+  - Zhuoren Li
+  - Ran Yu
+  - Yu Che
+  - Xinrui Zhang
+  - Ming Liu
+  - Jia Hu
+  - Chen Lv
+  - Bo Leng
+  arxiv_categories:
+  - cs.RO
+  - cs.LG
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2604.09059
+  title: Learning Vision-Language-Action World Models for Autonomous Driving
+  date: '2026-04-10'
+  updated: '2026-04-10'
+  url: https://arxiv.org/abs/2604.09059
+  abstract: 'Vision-Language-Action (VLA) models have recently achieved notable progress in end-to-end autonomous driving
+    by integrating perception, reasoning, and control within a unified multimodal framework. However, they often lack explicit
+    modeling of temporal dynamics and global world consistency, which limits their foresight and safety. In contrast, world
+    models can simulate plausible future scenes but generally struggle to reason about or evaluate the imagined future they
+    generate. In this work, we present VLA-World, a simple yet effective VLA world model that unifies predictive imagination
+    with reflective reasoning to improve driving foresight. VLA-World first uses an action-derived feasible trajectory to
+    guide the generation of the next-frame image, capturing rich spatial and temporal cues that describe how the surrounding
+    environment evolves. The model then reasons over this self-generated future imagined frame to refine the predicted trajectory,
+    achieving higher performance and better interpretability. To support this pipeline, we curate nuScenes-GR-20K, a generative
+    reasoning dataset derived from nuScenes, and employ a three-stage training strategy that includes pretraining, supervised
+    fine-tuning, and reinforcement learning. Extensive experiments demonstrate that VLA-World consistently surpasses state-of-the-art
+    VLA and world-model baselines on both planning and future-generation benchmarks. Project page: https://vlaworld.github.io'
+  authors:
+  - Guoqing Wang
+  - Pin Tang
+  - Xiangxuan Ren
+  - Guodongfang Zhao
+  - Bailan Feng
+  - Chao Ma
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2604.02714
+  title: 'ExploreVLA: Dense World Modeling and Exploration for End-to-End Autonomous Driving'
+  date: '2026-04-03'
+  updated: '2026-06-29'
+  url: https://arxiv.org/abs/2604.02714
+  abstract: 'End-to-end autonomous driving models based on Vision-Language-Action (VLA) architectures have shown promising
+    results by learning driving policies through behavior cloning on expert demonstrations. However, imitation learning inherently
+    limits the model to replicating observed behaviors without exploring diverse driving strategies, leaving it brittle in
+    novel or out-of-distribution scenarios. Reinforcement learning (RL) offers a natural remedy by enabling policy exploration
+    beyond the expert distribution. Yet VLA models, typically trained on offline datasets, lack directly observable state
+    transitions, necessitating a learned world model to anticipate action consequences. In this work, we propose a unified
+    understanding-and-generation framework that leverages world modeling to simultaneously enable meaningful exploration and
+    provide dense supervision. Specifically, we augment trajectory prediction with future RGB and depth image generation as
+    dense world modeling objectives, requiring the model to learn fine-grained visual and geometric representations that substantially
+    enrich the planning backbone. Beyond serving as a supervisory signal, the world model further acts as a source of intrinsic
+    reward for policy exploration: its image prediction uncertainty naturally measures a trajectory''s novelty relative to
+    the training distribution, where high uncertainty indicates out-of-distribution scenarios that, if safe, represent valuable
+    learning opportunities. We incorporate this exploration signal into a safety-gated reward and optimize the policy via
+    Group Relative Policy Optimization (GRPO). Experiments on the NAVSIM and nuScenes benchmarks demonstrate the effectiveness
+    of our approach, achieving a state-of-the-art PDMS score of 93.7 and an EPDMS of 88.8 on NAVSIM. The code'
+  authors:
+  - Zihao Sheng
+  - Xin Ye
+  - Jingru Luo
+  - Sikai Chen
+  - Liu Ren
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2505.16933
+  title: 'LLaDA-V: Large Language Diffusion Models with Visual Instruction Tuning'
+  date: '2025-05-22'
+  updated: '2025-06-04'
+  url: https://arxiv.org/abs/2505.16933
+  abstract: 'In this work, we introduce LLaDA-V, a purely diffusion-based Multimodal Large Language Model (MLLM) that integrates
+    visual instruction tuning with masked diffusion models, representing a departure from the autoregressive paradigms dominant
+    in current multimodal approaches. Built upon LLaDA, a representative large language diffusion model, LLaDA-V incorporates
+    a vision encoder and MLP connector that projects visual features into the language embedding space, enabling effective
+    multimodal alignment. Our empirical investigation reveals several intriguing results: First, LLaDA-V demonstrates promising
+    multimodal performance despite its language model being weaker on purely textual tasks than counterparts like LLaMA3-8B
+    and Qwen2-7B. When trained on the same instruction data, LLaDA-V is highly competitive to LLaMA3-V across multimodal tasks
+    with better data scalability. It also narrows the performance gap to Qwen2-VL, suggesting the effectiveness of its architecture
+    for multimodal tasks. Second, LLaDA-V achieves state-of-the-art performance in multimodal understanding compared to existing
+    hybrid autoregressive-diffusion and purely diffusion-based MLLMs. Our findings suggest that large language diffusion models
+    show promise in multimodal contexts and warrant further investigation in future research. Project page and codes: https://ml-gsai.github.io/LLaDA-V-demo/.'
+  authors:
+  - Zebin You
+  - Shen Nie
+  - Xiaolu Zhang
+  - Jun Hu
+  - Jun Zhou
+  - Zhiwu Lu
+  - Ji-Rong Wen
+  - Chongxuan Li
+  arxiv_categories:
+  - cs.LG
+  - cs.CL
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  - curated:multimodal-post-training
+  direction_hints:
+  - generative-media
+  - multimodal
+  - supervised-adaptation
+  status: candidate
+  review_priority: 2
+  rule_score: 5
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+  - curated-source:multimodal-post-training
+- id: arxiv:2607.12829
+  title: 'Accelerating Masked Diffusion Large Language Models: A Survey of Efficient Inference Techniques'
+  date: '2026-07-14'
+  updated: '2026-07-14'
+  url: https://arxiv.org/abs/2607.12829
+  abstract: Diffusion large language models (dLLMs) offer a theoretical advantage in parallel generation over standard autoregressive
+    models. However, parallel generation alone does not guarantee practical speedups. Realizing this efficiency requires specialized
+    inference mechanisms, such as diffusion-aware caching and reuse. Consequently, as inference efficiency becomes a prerequisite
+    for practical deployment, recent research has actively explored acceleration techniques across algorithms, architectures,
+    and systems. However, rigorous comparisons remain difficult, as end-to-end latency stems from intricate trade-offs between
+    algorithmic, architectural, and system-level factors that are often conflated in existing benchmarks. In this survey,
+    we introduce a unified latency decomposition framework for dLLMs to disentangle these factors and analyze their impact
+    on inference speed in real deployments. Guided by this framework, we categorize acceleration techniques along three axes
+    covering algorithmic innovations, architectural and system optimizations, and inference-time scaling. Finally, we provide
+    guidelines for reproducible benchmarking and highlight open challenges for realizing the full potential of parallel generation.
+  authors:
+  - Daehoon Gwak
+  - Minhyung Lee
+  - Junwoo Park
+  - Jaegul Choo
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.29275
+  title: 'Adaptive Block Diffusion: Resolving Training-Inference Mismatch in Diffusion Language Models'
+  date: '2026-06-28'
+  updated: '2026-06-28'
+  url: https://arxiv.org/abs/2606.29275
+  abstract: Diffusion Language Models (DLMs) are typically trained under fixed context structures, restricting denoising to
+    predetermined token subsets. This creates a mismatch between training and inference, where models must operate over arbitrary
+    configurations, leading to degradation off the training grid. We propose Adaptive Block Diffusion (ABD), which resolves
+    this mismatch by optimizing denoising risk over a distribution of prefix-window configurations. By treating the configuration
+    as a stochastic variable, ABD trains a single model over the full configuration space without architectural changes. We
+    show that generalization across decoding strategies is governed by the support of the training distribution, and that
+    ABD guarantees denoising optimality for any inference policy whose configurations are covered during training. Empirically,
+    ABD exhibits structural invariance across decoding scales, avoiding off-grid collapse and recovering a monotonic relationship
+    between block size and perplexity, while matching or outperforming fixed-block specialists at their target scales.
+  authors:
+  - Gagan Jain
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.25331
+  title: Improved Large Language Diffusion Models
+  date: '2026-06-24'
+  updated: '2026-06-24'
+  url: https://arxiv.org/abs/2606.25331
+  abstract: 'Modern large language models are predominantly trained with autoregressive factorization and causal attention.
+    We present \emph{iLLaDA}, an 8B masked diffusion language model trained from scratch with fully bidirectional attention.
+    iLLaDA keeps the masked diffusion objective throughout pre-training and supervised fine-tuning (SFT), scaling pre-training
+    to 12T tokens and fine-tuning on a 25B-token instruction corpus for 12 epochs. We further use variable-length generation
+    for efficiency and introduce confidence-based scoring for multiple-choice evaluation. Compared with LLaDA, iLLaDA improves
+    broadly across general, mathematical, and code benchmarks; for example, iLLaDA-Base improves by 21.6 points on BBH and
+    14.9 points on ARC-Challenge, while iLLaDA-Instruct improves by 14.5 points on MATH and 16.5 points on HumanEval. Despite
+    its non-autoregressive training, iLLaDA also remains competitive with Qwen2.5 7B on several benchmarks. These results
+    show that fully bidirectional diffusion training from scratch is a competitive path toward strong language models. Model
+    weights and codes: https://github.com/ML-GSAI/LLaDA.'
+  authors:
+  - Shen Nie
+  - Qiyang Min
+  - Shaoxuan Xu
+  - Zihao Huang
+  - Yuxuan Song
+  - Yong Shan
+  - Yankai Lin
+  - Wayne Xin Zhao
+  - Chongxuan Li
+  - Ji-Rong Wen
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.06712
+  title: Data-Efficient Autoregressive-to-Diffusion Language Models via On-Policy Distillation
+  date: '2026-06-04'
+  updated: '2026-06-04'
+  url: https://arxiv.org/abs/2606.06712
+  abstract: We study the transformation of autoregressive models (ARLMs) into diffusion language models (DLMs). Rather than
+    pretraining from scratch, prior work replaces the causal attention in ARLMs with bidirectional attention and then trains
+    the resulting model using a DLM objective. However, these approaches incur two distribution shifts. First, transitioning
+    from a next-token prediction objective to a DLM objective can discard knowledge acquired by the ARLM during training.
+    Second, standard DLMs suffer from a train-inference mismatch, as the training loss is defined on randomly masked sequences
+    rather than the trajectories encountered at inference produced by confidence-based decoding. To address both challenges,
+    we introduce an On-Policy Diffusion Language Model (OPDLM) in which On-Policy Distillation (OPD) is employed for ARLM-to-DLM
+    transformation. Specifically, OPDLM is trained via self-OPD, where the student, an ARLM with bidirectional attention,
+    generates its own trajectories, and the teacher, the original frozen ARLM, distills its knowledge by providing target
+    logits on these trajectories. By training directly in an on-policy manner, OPDLM eliminates the train-inference mismatch
+    in DLMs, while distillation from the original model enhances knowledge retention from the ARLM. Empirical results demonstrate
+    that OPDLM requires 15x to 7,000x fewer training tokens with strong performance across a wide variety of tasks. OPDLM
+    avoids the prohibitive cost of DLM pretraining and positions DLM transformation as a form of ARLM post-training.
+  authors:
+  - Xingyu Su
+  - Jacob Helwig
+  - Shubham Parashar
+  - Atharv Chagi
+  - Lakshmi Jotsna
+  - Degui Zhi
+  - James Caverlee
+  - Dileep Kalathil
+  - Shuiwang Ji
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.01026
+  title: 'Revise, Don''t Freeze: Sampler-Matched Training for Self-Correcting Masked Diffusion Language Models'
+  date: '2026-05-31'
+  updated: '2026-05-31'
+  url: https://arxiv.org/abs/2606.01026
+  abstract: 'Masked diffusion language models (MDLMs) re-predict every position at each denoising step, but standard samplers
+    commit tokens once revealed, leaving this revision capability unused. Existing approaches either add heuristic or learned
+    mechanisms to revise committed tokens, or remask them back to [MASK] before re-predicting; a principled sampler that directly
+    revises visible tokens without auxiliary modules remains underexplored. We introduce D3IM, a parameter-free sampler derived
+    as a corrector-style reverse update that permits direct visible-to-visible revision without additional modules or auxiliary
+    passes. D3IM also reveals a model-side obstacle we term preservation bias: the model tends to reproduce its own wrong
+    committed tokens rather than correct them. We address this with SCOPE (Self-Conditioned On Prediction Errors), a lightweight
+    post-training procedure that simulates D3IM''s sampling process. On LLaDA-8B at 64 denoising steps, SCOPE+D3IM improves
+    over the original LLaDA-8B with standard unmasking by +13.0 on GSM8K (68.3%), +4.8 on MATH-500 (23.6%), +15.3 on HumanEval
+    (29.3%), and +10.4 on MBPP (30.8%), with gains that increase as more denoising steps are used on math and HumanEval.'
+  authors:
+  - Longxuan Yu
+  - Shaorong Zhang
+  - Yu Fu
+  - Hui Liu
+  - Yue Dong
+  - Greg Ver Steeg
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.00722
+  title: 'EPIC: Efficient and Parallel Inference under CFG Constraints for Diffusion Language Models'
+  date: '2026-05-30'
+  updated: '2026-05-30'
+  url: https://arxiv.org/abs/2606.00722
+  abstract: Controlling language model outputs is essential for ensuring structural validity, reliability, and downstream
+    usability, and diffusion language models are no exception. Recent advances in diffusion language model decoding have extended
+    output control beyond regular constraints to context-free grammar (CFG) constraints. Existing methods, however, can be
+    up to four times slower than unconstrained decoding. More importantly, they substantially diminish one of the key advantages
+    of diffusion language models over autoregressive models, namely parallel decoding. This slowdown arises because sequential
+    validity checking introduces significant overhead during parallel generation. We propose an efficient CFG-constrained
+    decoding framework, EPIC, that addresses this limitation. Our method improves decoding efficiency by combining lexing
+    memoization, validation using Earley-style parsing instead of deterministic automata, and relaxed compatible subset selection
+    for parallel commit. It reduces repeated lexing and validation overhead while allowing multiple compatible tokens to be
+    committed together. Experiments on three benchmarks using four models show that our method reduces inference time by up
+    to 67.5% and decreases the additional overhead by up to 90.5% compared with existing CFG-constrained decoding methods.
+    Our implementation is available at https://github.com/hyundong98/EPIC-Decoding.git .
+  authors:
+  - Hyundong Jin
+  - Yo-Sub Han
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.29716
+  title: 'NaRA: Noise-Aware LoRA for Parameter-Efficient Fine-Tuning of Diffusion LLMs'
+  date: '2026-05-28'
+  updated: '2026-05-28'
+  url: https://arxiv.org/abs/2605.29716
+  abstract: Diffusion Large Language Models (dLLMs) have emerged as a promising non-autoregressive generative paradigm. Given
+    the prohibitive computational cost of full fine-tuning, Parameter-Efficient Fine-Tuning (PEFT) has become the standard
+    approach. However, existing PEFT methods (e.g., LoRA), originally tailored for autoregressive models, rely on static parameters
+    that are agnostic to the noise level. Consequently, they ignore the intrinsic dynamics of the diffusion process, where
+    input distributions and generation difficulty shift significantly along the denoising trajectory, rendering them suboptimal
+    for dLLMs. To address this, we propose Noise-aware Low-Rank Adaptation (NaRA), which introduces a low-rank core matrix
+    generated by a lightweight, globally shared hypernetwork conditioned on the noise level. This design enables the update
+    matrices to vary continuously along the diffusion process while keeping parameter and latency overhead negligible. We
+    provide a theoretical justification for the proposed NaRA framework and empirically demonstrate consistent improvements
+    over noise-agnostic baselines across commonsense reasoning, mathematical reasoning, and code generation benchmarks. Our
+    code is available at https://github.com/generaldi/NaRA.
+  authors:
+  - Shuaidi Wang
+  - Zhan Zhuang
+  - Ruping Huang
+  - Yu Zhang
+  arxiv_categories:
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.18165
+  title: 'Elastic-dLLM: Position Preserving Context Compression and Augmentation of Diffusion LLMs'
+  date: '2026-05-18'
+  updated: '2026-05-18'
+  url: https://arxiv.org/abs/2605.18165
+  abstract: Unlike autoregressive models, which generate one token at a time, dLLMs denoise a chunk of [MASK] tokens jointly
+    and sample one or more tokens per step; despite enabling parallel decoding, this process incurs substantial computational
+    cost due to the large chunk size of masked tokens. We observe that much of this cost is spent on repeatedly processing
+    the preceding context and many [MASK] tokens with the same feature representations, indicating considerable computational
+    redundancy. In this work, we revisit dLLM's redundancy from the perspective of [MASK] tokens. Through systematic analysis,
+    we verify the redundancy of [MASK] tokens while revealing their critical role in providing structural information. Guided
+    by these findings, we propose position-preserving [MASK] token compression and terminal-aware augmentation. By compressing
+    redundant [MASK] computation, this approach accelerates decoding and further provides a natural extension toward context-folding-like
+    long-context scaling under limited input-length constraints for full-sequence dLLMs such as LLaDA-8B-Instruct and LLaDA-1.5.
+    Moreover, for block dLLMs such as LLaDA2.0-mini, it augments the context with a protected terminal [MASK] token to enhance
+    generation quality with negligible overhead.
+  authors:
+  - Junyi Wu
+  - Tianchen Zhao
+  - Shaoqiu Zhang
+  - Linfeng Zhang
+  - Guohao Dai
+  - Yu Wang
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.17174
+  title: 'Beyond Execution: Static-Analysis Rewards and Hint-Conditioned Diffusion RL for Code Generation'
+  date: '2026-05-16'
+  updated: '2026-05-16'
+  url: https://arxiv.org/abs/2605.17174
+  abstract: 'Reinforcement Learning (RL) is an important paradigm for aligning Diffusion Language Models (DLMs) toward functional
+    correctness in code generation. However, these models often encounter a ``capability cliff'''' on complex tasks, where
+    execution-based semantic rewards become too low to provide a viable learning signal. In this paper, we present a systematic
+    empirical study of RL post-training for diffusion-based code generation along three axes: reward design, hint-conditioned
+    sampling, and task difficulty. We investigate the effectiveness of execution-free rewards as alternatives to traditional
+    unit-test execution, the role of training-time hint-conditioned diffusion sampling in mitigating exploration bottlenecks,
+    and the impact of these design choices varies across tasks with different difficulty levels. Across HumanEval, MBPP, and
+    LiveCodeBench, we find that static checking is the strongest overall standalone execution-free reward in our setting,
+    especially improving DiffuCoder from 53.9 to 67.1 on HumanEval and from 14.9 to 15.5 on LiveCodeBench while reducing rollout
+    time by 9.4\%. We further find that moderate AST-based hinting is most useful on harder benchmarks, while the best reward
+    design depends strongly on task difficulty: similarity-based rewards are more effective on easier subsets, whereas static
+    checking is more reliable on harder subsets where execution rewards are low. These findings suggest that reward design
+    and training guidance substantially affect diffusion RL performance in our evaluated code-generation setting.'
+  authors:
+  - Shuyin Ouyang
+  - Zhaozhi Qian
+  - Faroq AL-Tam
+  - Muhammad AL-Qurishi
+  - Jie M. Zhang
+  arxiv_categories:
+  - cs.SE
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.16829
+  title: Constrained Code Generation with Discrete Diffusion
+  date: '2026-05-16'
+  updated: '2026-05-16'
+  url: https://arxiv.org/abs/2605.16829
+  abstract: Discrete diffusion models are a powerful, emerging paradigm for code generation. They construct programs through
+    iterative refinement of partially corrupted token sequences and enable parallel token refinement. Importantly, this paradigm
+    exposes a global program state at each denoising step, which provides a natural intervention point for enforcing program-level
+    functionality and security constraints, guiding the generation before the final code is committed. Building on this observation,
+    the paper introduces Constrained Diffusion for Code (CDC), a training-free neurosymbolic inference framework that integrates
+    constraint satisfaction directly into the reverse denoising process. CDC augments the base discrete diffusion sampler
+    with constraint-aware denoising operators that combine mathematical optimization with program analysis to identify constraint-relevant
+    regions of the intermediate program state and locally adjust the denoising trajectory, steering generation toward feasible
+    programs while remaining close to the base model. Across code generation benchmarks, CDC consistently improves constraint
+    satisfaction in functional correctness, security, and even syntax, outperforming discrete diffusion and autoregressive
+    baselines with less corrective computation and more localized edits.
+  authors:
+  - Lize Shao
+  - Michael Cardei
+  - Zichen Xie
+  - Ferdinando Fioretto
+  - Wenxi Wang
+  arxiv_categories:
+  - cs.CL
+  - cs.PL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.13935
+  title: 'Beyond Mode-Seeking RL: Trajectory-Balance Post-Training for Diffusion Language Models'
+  date: '2026-05-13'
+  updated: '2026-05-13'
+  url: https://arxiv.org/abs/2605.13935
+  abstract: 'Diffusion language models are a promising alternative to autoregressive models, yet post-training methods for
+    them largely adapt reward-maximizing objectives. We identify a central failure mode in this setting we call trajectory
+    locking: sampled reward-driven updates over-concentrate probability mass onto a narrow set of denoising paths, reducing
+    coverage of alternative correct solutions under repeated sampling. To address this, we propose TraFL (Trajectory Flow
+    baLancing), a trajectory-balance objective that trains the policy toward a reward-tilted target distribution anchored
+    to a frozen reference model. We make this practical for diffusion language models with a diffusion-compatible sequence-level
+    surrogate and a learned prompt-dependent normalization. Across mathematical reasoning and code generation benchmarks,
+    TraFL is the only evaluated post-training method that improves over the base model in every benchmark-length setting,
+    with gains that persist as the sampling budget increases. The improvements transfer to held-out evaluations: TraFL stays
+    above the base model on Minerva Math and is the strongest method on every LiveCodeBench difficulty split.'
+  authors:
+  - Saba Ahmadi
+  - Prasanna Parthasarathi
+  - Yufei Cui
+  arxiv_categories:
+  - cs.LG
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.07701
+  title: 'Guidance Is Not a Hyperparameter: Learning Dynamic Control in Diffusion Language Models'
+  date: '2026-05-08'
+  updated: '2026-05-08'
+  url: https://arxiv.org/abs/2605.07701
+  abstract: Classifier-Free Guidance (CFG) is a widely used mechanism for controlling diffusion-based generative models, yet
+    its guidance scale is typically treated as a fixed hyperparameter throughout generation. This static design yields a suboptimal
+    controllability and quality tradeoff, as the optimal degree of guidance varies across tasks and across different stages
+    of the diffusion process, especially in NLP domain. We recast CFG scale selection as a sequential decision-making problem
+    and propose to learn dynamic guidance trajectories via reinforcement learning. Specifically, we model the guidance scale
+    as a discrete control action selected at each generation step based on the evolving diffusion state, and optimize a policy
+    using Proximal Policy Optimization (PPO) under task-level rewards. Experiments on three controlled NLP generation tasks
+    using discrete diffusion language models demonstrate that adaptive guidance consistently achieves a better balance between
+    controllability and generation quality than fixed-scale strategies. Further analysis of the learned policies reveals distinct
+    and interpretable guidance trajectories across tasks, underscoring the importance of treating guidance as a dynamic control
+    process rather than a static design choice.
+  authors:
+  - Fan Zhou
+  - Tim Van de Cruys
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.06885
+  title: 'Don''t Retrain, Align: Adapting Autoregressive LMs to Diffusion LMs via Representation Alignment'
+  date: '2026-05-07'
+  updated: '2026-05-07'
+  url: https://arxiv.org/abs/2605.06885
+  abstract: Diffusion language models (DLMs) have recently demonstrated capabilities that complement standard autoregressive
+    (AR) models, particularly in non-sequential generation and bidirectional editing. Although recent work has shown that
+    pretrained autoregressive checkpoints can be converted into diffusion language models, existing recipes primarily transfer
+    parameters through continued denoising training with objective- and attention-level modifications. We instead ask whether
+    the internal representation geometry learned by next-token prediction can be explicitly preserved during AR-to-DLM conversion.
+    We hypothesize that much of the semantic structure learned by AR pretraining can transfer across generation orders, and
+    thus DLM training should be viewed as relearning the decoding path rather than relearning language representations. To
+    investigate this, we introduce REPR-ALIGN, a representation alignment objective that adapts a bidirectional masked diffusion
+    model to reuse representations from a pretrained AR model of identical architecture. Concretely, we align the hidden states
+    of the DLM to the frozen AR model at every layer using cosine similarity, while optimizing the standard masked denoising
+    objective. This simple alignment, with no adapters and no architectural changes beyond the attention mask, yields up to
+    4x training acceleration in our setting and is particularly effective in low-data regimes. Our results suggest that linguistic
+    representations can transfer across generation order, and that representation alignment provides a simple and effective
+    technique for training diffusion language models. Code is available at https://github.com/pengzhangzhi/Open-dLLM.
+  authors:
+  - Fred Zhangzhi Peng
+  - Alexis Fox
+  - Anru R. Zhang
+  - Alexander Tong
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2607.08056
+  title: Reinforcing the Generation Order of Multimodal Masked Diffusion Models
+  date: '2026-07-09'
+  updated: '2026-07-09'
+  url: https://arxiv.org/abs/2607.08056
+  abstract: Diffusion Language Models (DLMs) have recently achieved substantial progress in natural language generation tasks.
+    Recent research demonstrates that adaptive token generation ordering can significantly improve performance in mathematical
+    reasoning and code synthesis applications. In this work, we investigate the optimization of generation order for both
+    text-to-image synthesis and multimodal understanding. We first establish that, unlike structured problems in language
+    generation such as Sudoku puzzles, model logits alone are insufficient for determining optimal generation sequences in
+    text-to-image generation and multimodal understanding. To address this challenge, we introduce a learnable control module
+    trained via Group Relative Policy Optimization (GRPO) to determine the generation order. Our results demonstrate that
+    learning this control block substantially improves both text-to-image alignment and multimodal understanding in DLMs.
+    In particular, it enhances the model's ability to capture fine-grained spatial relationships in generated images while
+    also strengthening performance on multimodal reasoning and comprehension tasks. We evaluate our framework on GenEval,
+    an object-focused benchmark for text-to-image alignment, where it achieves 4.08% relative improvements. In addition, experiments
+    on VLMEvalKit confirm 4.85% relative improvements in multimodal understanding, highlighting the broad effectiveness of
+    our approach.
+  authors:
+  - Yidong Ouyang
+  - Zhe Wang
+  - Sourav Bhabesh
+  - Dmitriy Bespalov
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - stat.ML
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.23623
+  title: 'dVLA-RL: Reinforcement Learning over Denoising Trajectories for Discrete Diffusion Vision-Language-Action Models'
+  date: '2026-06-22'
+  updated: '2026-06-22'
+  url: https://arxiv.org/abs/2606.23623
+  abstract: Vision-Language-Action (VLA) models have established a powerful paradigm for generalist robotic manipulation by
+    grounding control into the semantic reasoning of VLMs. Prevailing architectures typically model actions continuously via
+    diffusion or flow processes, or discretely through either autoregressive generation or parallel decoding. Recently, Discrete
+    Diffusion VLAs (dVLAs) have emerged as a distinct alternative, unifying vision, language, and action into a single discrete
+    token space via masked generative modeling. While combining iterative refinement with unified representations, its training
+    has thus far been restricted to Supervised Fine-Tuning (SFT), leaving the potential of Reinforcement Learning (RL) for
+    further policy refinement largely unexplored. A fundamental challenge in RL for dVLAs is that the marginal probability
+    of the final action generated by dVLAs remains intractable. To solve this problem, we propose \textbf{dVLA-RL}, shifting
+    the learning objective from the marginal action probability to the joint probability of the sampled generation path. Specifically,
+    by modeling the denoising process as a Markov Decision Process (MDP), we mathematically formulate this path probability
+    as a product of step-wise transitions. This trajectory-level objective provides a unified formulation that natively accommodates
+    variable denoising steps. Leveraging this intrinsic fexibility, we introduce a unified step scheduling approach for complex
+    multi-task learning, tailoring denoising steps to specific task complexities to maximize both success rates and computational
+    effciency. Extensive evaluations demonstrate that our approach achieves a success rate of \textbf{99.7\%} on LIBERO. Furthermore,
+    it establishes strong VLA-based results on RoboTwin 2.0 by delivering a \te
+  authors:
+  - Yuhao Wu
+  - Yitian Liu
+  - Weijie Shen
+  - Mishuo Han
+  - Wenjie Xu
+  - Haotian Liang
+  - Zhongshan Liu
+  - Yinan Mao
+  - Lei Xu
+  - Xinping Guan
+  - Ru Ying
+  - Ran Zheng
+  - Wei Sui
+  - Xiaokang Yang
+  - Wenbo Ding
+  - Yao Mu
+  arxiv_categories:
+  - cs.RO
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.19534
+  title: 'PerceptionDLM: Parallel Region Perception with Multimodal Diffusion Language Models'
+  date: '2026-06-17'
+  updated: '2026-06-17'
+  url: https://arxiv.org/abs/2606.19534
+  abstract: Multimodal large language models (MLLMs) have achieved remarkable progress in visual understanding tasks. However,
+    most existing MLLMs rely on autoregressive generation, which limits their efficiency for perception tasks that require
+    captioning multiple regions. In this work, we propose PerceptionDLM, a multimodal diffusion language model optimized for
+    efficient parallel region perception. Built upon PerceptionDLM-Base, a strong foundational baseline that achieves state-of-the-art
+    performance among open-source diffusion MLLMs, our architecture fully leverages the parallel decoding nature of DLMs.
+    Specifically, we introduce efficient prompting and structured attention masking to enable simultaneous perception of multiple
+    masked regions, allowing the model to generate region descriptions in parallel at both the sequence and token levels.
+    This design significantly improves inference efficiency compared with existing approaches that process regions sequentially.
+    To systematically evaluate the parallelism property of visual perception capability for DLMs, we construct a new Parallel
+    Detailed Localized Captioning Benchmark (ParaDLC-Bench) by scaling the DLC-Bench to include multiple region masks per
+    image, enabling joint evaluation of both caption quality and inference efficiency. Experiments demonstrate that PerceptionDLM
+    maintains competitive performance in region captioning while achieving substantial speed improvements for multi-region
+    perception tasks. Our results highlight the potential of multimodal diffusion language models for efficient, parallel
+    visual perception. To the best of our knowledge, we are the first to achieve parallel region caption and perception by
+    leveraging the advantages of diffusion language models. Code, models, and datasets are released.
+  authors:
+  - Yueyi Sun
+  - Yuhao Wang
+  - Jason Li
+  - Ye Tian
+  - Tao Zhang
+  - Jacky Mai
+  - Yihan Wang
+  - Haochen Wang
+  - Jinbin Bai
+  - Ling Yang
+  - Yunhai Tong
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2606.14792
+  title: Efficient Reinforcement for Visual-Textual Thinking with Discrete Diffusion Model
+  date: '2026-06-11'
+  updated: '2026-06-11'
+  url: https://arxiv.org/abs/2606.14792
+  abstract: RL-based post-training has been widely adopted to enable interleaved visual and textual reasoning in unified multimodal
+    models capable of both text and image generation. However, most existing approaches are built upon autoregressive (AR)
+    unified models, which require full image regeneration during visual reasoning. In this work, we demonstrate that multimodal
+    discrete diffusion models are effective alternatives to AR models for reinforcement learning in interleaved reasoning,
+    owing to their ability to perform efficient visual rollouts via localized visual editing rather than full image-token
+    regeneration. This reduces rollout computation during GRPO by 26.9\% compared to AR baselines, with minimal performance
+    drop. Despite the improved efficiency, we find that joint reward assignment, which employs a shared reward signal across
+    modalities, introduces cross-modal interference between unrelated image and text token sequences during RL updates. To
+    address this issue, we propose factorized reward assignment, a strategy that assigns rewards independently to text and
+    vision segments. With factorized reward assignment, our RL approach achieves an 11.2% improvement over joint reward assignment
+    and a 38.04% improvement over the base model.
+  authors:
+  - Yoonjeon Kim
+  - Yuhta Takida
+  - Chieh-Hsin Lai
+  - Eunho Yang
+  - Yuki Mitsufuji
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.04874
+  title: Uncertainty-Aware Exploratory Direct Preference Optimization for Multimodal Large Language Models
+  date: '2026-05-06'
+  updated: '2026-05-06'
+  url: https://arxiv.org/abs/2605.04874
+  abstract: 'Direct Preference Optimization (DPO) has proven to be an effective solution for mitigating hallucination in Multimodal
+    Large Language Models (MLLMs) by learning from preference pairs. One of its key challenges lies in how to transfer the
+    sequence-level preference into fine-grained supervision on visual fidelity. To safeguard vision-related tokens that are
+    prone to hallucination, existing methods typically allocate training emphasis according to the model''s self-assessed
+    visual sensitivity signals. However, such sensitivity, estimated by a model still under training, introduces self-referential
+    bias: reinforcing already well-learned visual cues while neglecting hard-to-perceive but critical details, thereby limiting
+    deeper alignment. In this work, we propose an Uncertainty-aware Exploratory Direct Preference Optimization (UE-DPO) method
+    for MLLMs, which enables the model to uncover its cognitive deficiencies and actively explore for self-correction, guided
+    by token-level epistemic uncertainty. Specifically, we first quantify the uncertainty from the model''s failure to ground
+    token predictions in the given image. Then, based on an uncertainty-aware exploration intensity, we encourage more learning
+    pressure on visually deficient tokens in preferred samples, and alleviate the over-penalization of beneficial knowledge
+    in dispreferred samples. Further, we provide a theoretical justification for our method, and extensive experiments demonstrate
+    its effectiveness and robustness.'
+  authors:
+  - Huatian Zhang
+  - Zhendong Mao
+  - Lei Zhang
+  - Yongdong Zhang
+  arxiv_categories:
+  - cs.LG
+  - cs.CL
+  - cs.CV
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2604.20796
+  title: 'LLaDA2.0-Uni: Unifying Multimodal Understanding and Generation with Diffusion Large Language Model'
+  date: '2026-04-22'
+  updated: '2026-04-22'
+  url: https://arxiv.org/abs/2604.20796
+  abstract: We present LLaDA2.0-Uni, a unified discrete diffusion large language model (dLLM) that supports multimodal understanding
+    and generation within a natively integrated framework. Its architecture combines a fully semantic discrete tokenizer,
+    a MoE-based dLLM backbone, and a diffusion decoder. By discretizing continuous visual inputs via SigLIP-VQ, the model
+    enables block-level masked diffusion for both text and vision inputs within the backbone, while the decoder reconstructs
+    visual tokens into high-fidelity images. Inference efficiency is enhanced beyond parallel decoding through prefix-aware
+    optimizations in the backbone and few-step distillation in the decoder. Supported by carefully curated large-scale data
+    and a tailored multi-stage training pipeline, LLaDA2.0-Uni matches specialized VLMs in multimodal understanding while
+    delivering strong performance in image generation and editing. Its native support for interleaved generation and reasoning
+    establishes a promising and scalable paradigm for next-generation unified foundation models. Codes and models are available
+    at https://github.com/inclusionAI/LLaDA2.0-Uni.
+  authors:
+  - Inclusion AI
+  - Tiwei Bie
+  - Haoxing Chen
+  - Tieyuan Chen
+  - Zhenglin Cheng
+  - Long Cui
+  - Kai Gan
+  - Zhicheng Huang
+  - Zhenzhong Lan
+  - Haoquan Li
+  - Jianguo Li
+  - Tao Lin
+  - Qi Qin
+  - Hongjun Wang
+  - Xiaomei Wang
+  - Haoyuan Wu
+  - Yi Xin
+  - Junbo Zhao
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2604.05497
+  title: 'Thinking Diffusion: Penalize and Guide Visual-Grounded Reasoning in Diffusion Multimodal Language Models'
+  date: '2026-04-07'
+  updated: '2026-04-07'
+  url: https://arxiv.org/abs/2604.05497
+  abstract: Diffusion large language models (dLLMs) are emerging as promising alternatives to autoregressive (AR) LLMs. Recently,
+    this paradigm has been extended to multimodal tasks, leading to the development of diffusion multimodal large language
+    models (dMLLMs). These models are expected to retain the reasoning capabilities of LLMs while enabling faster inference
+    through parallel generation. However, when combined with Chain-of-Thought (CoT) reasoning, dMLLMs exhibit two critical
+    issues. First, we observe that dMLLMs often generate the final answer token at a very early timestep. This trend indicates
+    that the model determines the answer before sufficient reasoning, leading to degraded reasoning performance. Second, during
+    the initial timesteps, dMLLMs show minimal dependency on visual prompts, exhibiting a fundamentally different pattern
+    of visual information utilization compared to AR vision-language models. In summary, these findings indicate that dMLLMs
+    tend to generate premature final answers without sufficiently grounding on visual inputs. To address these limitations,
+    we propose Position and Step Penalty (PSP) and Visual Reasoning Guidance (VRG). PSP penalizes tokens in later positions
+    during early timesteps, delaying premature answer generation and encouraging progressive reasoning across timesteps. VRG,
+    inspired by classifier-free guidance, amplifies visual grounding signals to enhance the model's alignment with visual
+    evidence. Extensive experiments across various dMLLMs demonstrate that our method achieves up to 7.5% higher accuracy
+    while delivering more than 3x speedup compared to reasoning with four times more diffusion steps.
+  authors:
+  - Keuntae Kim
+  - Mingyu Kang
+  - Yong Suk Choi
+  arxiv_categories:
+  - cs.AI
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2406.07394
+  title: Accessing GPT-4 level Mathematical Olympiad Solutions via Monte Carlo Tree Self-refine with LLaMa-3 8B
+  date: '2024-06-11'
+  updated: '2024-06-13'
+  url: https://arxiv.org/abs/2406.07394
+  abstract: This paper introduces the MCT Self-Refine (MCTSr) algorithm, an innovative integration of Large Language Models
+    (LLMs) with Monte Carlo Tree Search (MCTS), designed to enhance performance in complex mathematical reasoning tasks. Addressing
+    the challenges of accuracy and reliability in LLMs, particularly in strategic and mathematical reasoning, MCTSr leverages
+    systematic exploration and heuristic self-refine mechanisms to improve decision-making frameworks within LLMs. The algorithm
+    constructs a Monte Carlo search tree through iterative processes of Selection, self-refine, self-evaluation, and Backpropagation,
+    utilizing an improved Upper Confidence Bound (UCB) formula to optimize the exploration-exploitation balance. Extensive
+    experiments demonstrate MCTSr's efficacy in solving Olympiad-level mathematical problems, significantly improving success
+    rates across multiple datasets, including GSM8K, GSM Hard, MATH, and Olympiad-level benchmarks, including Math Odyssey,
+    AIME, and OlympiadBench. The study advances the application of LLMs in complex reasoning tasks and sets a foundation for
+    future AI integration, enhancing decision-making accuracy and reliability in LLM-driven applications.
+  authors:
+  - Di Zhang
+  - Xiaoshui Huang
+  - Dongzhan Zhou
+  - Yuqiang Li
+  - Wanli Ouyang
+  arxiv_categories:
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  - curated:preference-learning
+  direction_hints:
+  - preference-alignment
+  - unclassified
+  status: candidate
+  review_priority: 2
+  rule_score: 5
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+  - curated-source:preference-learning
+- id: arxiv:2604.15705
+  title: 'Towards Robust Endogenous Reasoning: Unifying Drift Adaptation in Non-Stationary Tuning'
+  date: '2026-04-17'
+  updated: '2026-04-17'
+  url: https://arxiv.org/abs/2604.15705
+  abstract: 'Reinforcement Fine-Tuning (RFT) has established itself as a critical paradigm for the alignment of Multi-modal
+    Large Language Models (MLLMs) with complex human values and domain-specific requirements. Nevertheless, current research
+    primarily focuses on mitigating exogenous distribution shifts arising from data-centric factors, the non-stationarity
+    inherent in the endogenous reasoning remains largely unexplored. In this work, a critical vulnerability is revealed within
+    MLLMs: they are highly susceptible to endogenous reasoning drift, across both thinking and perception perspectives. It
+    manifests as unpredictable distribution changes that emerge spontaneously during the autoregressive generation process,
+    independent of external environmental perturbations. To adapt it, we first theoretically define endogenous reasoning drift
+    within the RFT of MLLMs as the multi-modal concept drift. In this context, this paper proposes Counterfactual Preference
+    Optimization ++ (CPO++), a comprehensive and autonomous framework adapted to the multi-modal concept drift. It integrates
+    counterfactual reasoning with domain knowledge to execute controlled perturbations across thinking and perception, employing
+    preference optimization to disentangle spurious correlations. Extensive empirical evaluations across two highly dynamic
+    and safety-critical domains: medical diagnosis and autonomous driving. They demonstrate that the proposed framework achieves
+    superior performance in reasoning coherence, decision-making precision, and inherent robustness against extreme interference.
+    The methodology also exhibits exceptional zero-shot cross-domain generalization, providing a principled foundation for
+    reliable multi-modal reasoning in safety-critical applications.'
+  authors:
+  - Xiaoyu Yang
+  - En Yu
+  - Wei Duan
+  - Jie Lu
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - preference-alignment
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2604.04215
+  title: 'DARE: Diffusion Large Language Models Alignment and Reinforcement Executor'
+  date: '2026-04-05'
+  updated: '2026-04-05'
+  url: https://arxiv.org/abs/2604.04215
+  abstract: Diffusion large language models (dLLMs) are emerging as a compelling alternative to dominant autoregressive models,
+    replacing strictly sequential token generation with iterative denoising and parallel generation dynamics. However, their
+    open-source ecosystem remains fragmented across model families and, in particular, across post-training pipelines, where
+    reinforcement learning objectives, rollout implementations and evaluation scripts are often released as paper-specific
+    codebases. This fragmentation slows research iteration, raises the engineering burden of reproduction, and makes fair
+    comparison across algorithms difficult. We present \textbf{DARE} (\textbf{d}LLMs \textbf{A}lignment and \textbf{R}einforcement
+    \textbf{E}xecutor), an open framework for post-training and evaluating dLLMs. Built on top of verl~\cite{sheng2024hybridflow}
+    and OpenCompass~\cite{2023opencompass}, DARE unifies supervised fine-tuning, parameter-efficient fine-tuning, preference
+    optimization, and dLLM-specific reinforcement learning under a shared execution stack for both masked and block diffusion
+    language models. Across representative model families including LLaDA, Dream, SDAR, and LLaDA2.x, DARE provides broad
+    algorithmic coverage, reproducible benchmark evaluation, and practical acceleration. Extensive empirical results position
+    that DARE serves as a reusable research substrate for developing, comparing, and deploying post-training methods for current
+    and emerging dLLMs.
+  authors:
+  - Jingyi Yang
+  - Yuxian Jiang
+  - Xuhao Hu
+  - Shuang Cheng
+  - Biqing Qi
+  - Jing Shao
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - preference-alignment
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2604.01723
+  title: Causal Scene Narration with Runtime Safety Supervision for Vision-Language-Action Driving
+  date: '2026-04-02'
+  updated: '2026-04-02'
+  url: https://arxiv.org/abs/2604.01723
+  abstract: Vision-Language-Action (VLA) models for autonomous driving must integrate diverse textual inputs, including navigation
+    commands, hazard warnings, and traffic state descriptions, yet current systems often present these as disconnected fragments,
+    forcing the model to discover on its own which environmental constraints are relevant to the current maneuver. We introduce
+    Causal Scene Narration (CSN), which restructures VLA text inputs through intent-constraint alignment, quantitative grounding,
+    and structured separation, at inference time with zero GPU cost. We complement CSN with Simplex-based runtime safety supervision
+    and training-time alignment via Plackett-Luce DPO with negative log-likelihood (NLL) regularization. A multi-town closed-loop
+    CARLA evaluation shows that CSN improves Driving Score by +31.1% on original LMDrive and +24.5% on the preference-aligned
+    variant. A controlled ablation reveals that causal structure accounts for 39.1% of this gain, with the remainder attributable
+    to information content alone. A perception noise ablation confirms that CSN's benefit is robust to realistic sensing errors.
+    Semantic safety supervision improves Infraction Score, while reactive Time-To-Collision monitoring degrades performance,
+    demonstrating that intent-aware monitoring is needed for VLA systems.
+  authors:
+  - Yun Li
+  - Yidu Zhang
+  - Simon Thompson
+  - Ehsan Javanmardi
+  - Manabu Tsukada
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.25740
+  title: 'Drive My Way: Preference Alignment of Vision-Language-Action Model for Personalized Driving'
+  date: '2026-03-26'
+  updated: '2026-03-26'
+  url: https://arxiv.org/abs/2603.25740
+  abstract: Human driving behavior is inherently personal, which is shaped by long-term habits and influenced by short-term
+    intentions. Individuals differ in how they accelerate, brake, merge, yield, and overtake across diverse situations. However,
+    existing end-to-end autonomous driving systems either optimize for generic objectives or rely on fixed driving modes,
+    lacking the ability to adapt to individual preferences or interpret natural language intent. To address this gap, we propose
+    Drive My Way (DMW), a personalized Vision-Language-Action (VLA) driving framework that aligns with users' long-term driving
+    habits and adapts to real-time user instructions. DMW learns a user embedding from our personalized driving dataset collected
+    across multiple real drivers and conditions the policy on this embedding during planning, while natural language instructions
+    provide additional short-term guidance. Closed-loop evaluation on the Bench2Drive benchmark demonstrates that DMW improves
+    style instruction adaptation, and user studies show that its generated behaviors are recognizable as each driver's own
+    style, highlighting personalization as a key capability for human-centered autonomous driving. Our data and code are available
+    at https://dmw-cvpr.github.io/.
+  authors:
+  - Zehao Wang
+  - Huaide Jiang
+  - Shuaiwu Dong
+  - Yuping Wang
+  - Hang Qiu
+  - Jiachen Li
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  - cs.CV
+  - cs.LG
+  - cs.MA
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.03192
+  title: 'MoD-DPO: Towards Mitigating Cross-modal Hallucinations in Omni LLMs using Modality Decoupled Preference Optimization'
+  date: '2026-03-03'
+  updated: '2026-03-27'
+  url: https://arxiv.org/abs/2603.03192
+  abstract: Omni-modal large language models (omni LLMs) have recently achieved strong performance across audiovisual understanding
+    tasks, yet they remain highly susceptible to cross-modal hallucinations arising from spurious correlations and dominant
+    language priors. In this work, we propose Modality-Decoupled Direct Preference Optimization (MoD-DPO), a simple and effective
+    framework for improving modality grounding in omni LLMs. MoD-DPO introduces modality-aware regularization terms that explicitly
+    enforce invariance to corruptions in irrelevant modalities and sensitivity to perturbations in relevant modalities, thereby
+    reducing unintended cross-modal interactions. To further mitigate over-reliance on textual priors, we incorporate a language-prior
+    debiasing penalty that discourages hallucination-prone text-only responses. Extensive experiments across multiple audiovisual
+    hallucination benchmarks demonstrate that MoD-DPO consistently improves perception accuracy and hallucination resistance,
+    outperforming previous preference optimization baselines under similar training budgets. Our findings underscore the importance
+    of modality-faithful alignment and demonstrate a scalable path toward more reliable and resilient multimodal foundation
+    models.
+  authors:
+  - Ashutosh Chaubey
+  - Jiacheng Pang
+  - Mohammad Soleymani
+  arxiv_categories:
+  - cs.CV
+  - cs.CL
+  - cs.LG
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2601.00623
+  title: 'DA-DPO: Cost-efficient Difficulty-aware Preference Optimization for Reducing MLLM Hallucinations'
+  date: '2026-01-02'
+  updated: '2026-01-02'
+  url: https://arxiv.org/abs/2601.00623
+  abstract: 'Direct Preference Optimization (DPO) has shown strong potential for mitigating hallucinations in Multimodal Large
+    Language Models (MLLMs). However, existing multimodal DPO approaches often suffer from overfitting due to the difficulty
+    imbalance in preference data. Our analysis shows that MLLMs tend to overemphasize easily distinguishable preference pairs,
+    which hinders fine-grained hallucination suppression and degrades overall performance. To address this issue, we propose
+    Difficulty-Aware Direct Preference Optimization (DA-DPO), a cost-effective framework designed to balance the learning
+    process. DA-DPO consists of two main components: (1) Difficulty Estimation leverages pre-trained vision--language models
+    with complementary generative and contrastive objectives, whose outputs are integrated via a distribution-aware voting
+    strategy to produce robust difficulty scores without additional training; and (2) Difficulty-Aware Training reweights
+    preference pairs based on their estimated difficulty, down-weighting easy samples while emphasizing harder ones to alleviate
+    overfitting. This framework enables more effective preference optimization by prioritizing challenging examples, without
+    requiring new data or extra fine-tuning stages. Extensive experiments demonstrate that DA-DPO consistently improves multimodal
+    preference optimization, yielding stronger robustness to hallucinations and better generalization across standard benchmarks,
+    while remaining computationally efficient. The project page is available at https://artanic30.github.io/project_pages/DA-DPO/.'
+  authors:
+  - Longtian Qiu
+  - Shan Ning
+  - Chuyu Zhang
+  - Jiaxuan Sun
+  - Xuming He
+  arxiv_categories:
+  - cs.AI
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2512.17370
+  title: 'TakeAD: Preference-based Post-optimization for End-to-end Autonomous Driving with Expert Takeover Data'
+  date: '2025-12-19'
+  updated: '2025-12-22'
+  url: https://arxiv.org/abs/2512.17370
+  abstract: 'Existing end-to-end autonomous driving methods typically rely on imitation learning (IL) but face a key challenge:
+    the misalignment between open-loop training and closed-loop deployment. This misalignment often triggers driver-initiated
+    takeovers and system disengagements during closed-loop execution. How to leverage those expert takeover data from disengagement
+    scenarios and effectively expand the IL policy''s capability presents a valuable yet unexplored challenge. In this paper,
+    we propose TakeAD, a novel preference-based post-optimization framework that fine-tunes the pre-trained IL policy with
+    this disengagement data to enhance the closed-loop driving performance. First, we design an efficient expert takeover
+    data collection pipeline inspired by human takeover mechanisms in real-world autonomous driving systems. Then, this post
+    optimization framework integrates iterative Dataset Aggregation (DAgger) for imitation learning with Direct Preference
+    Optimization (DPO) for preference alignment. The DAgger stage equips the policy with fundamental capabilities to handle
+    disengagement states through direct imitation of expert interventions. Subsequently, the DPO stage refines the policy''s
+    behavior to better align with expert preferences in disengagement scenarios. Through multiple iterations, the policy progressively
+    learns recovery strategies for disengagement states, thereby mitigating the open-loop gap. Experiments on the closed-loop
+    Bench2Drive benchmark demonstrate our method''s effectiveness compared with pure IL methods, with comprehensive ablations
+    confirming the contribution of each component.'
+  authors:
+  - Deqing Liu
+  - Yinfeng Gao
+  - Deheng Qian
+  - Qichao Zhang
+  - Xiaoqing Ye
+  - Junyu Han
+  - Yupeng Zheng
+  - Xueyi Liu
+  - Zhongpu Xia
+  - Dawei Ding
+  - Yifeng Pan
+  - Dongbin Zhao
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2510.23658
+  title: Aligning Diffusion Language Models via Unpaired Preference Optimization
+  date: '2025-10-26'
+  updated: '2025-11-12'
+  url: https://arxiv.org/abs/2510.23658
+  abstract: Diffusion language models (dLLMs) are an emerging alternative to autoregressive (AR) generators, but aligning
+    them to human preferences is challenging because sequence log-likelihoods are intractable and pairwise preference data
+    are costly to collect. We introduce ELBO-KTO, which combines an ELBO surrogate for diffusion log-likelihoods with a prospect-theoretic,
+    unpaired preference objective (Kahneman Tversky Optimization, KTO). We analyze the bias and variance induced by the ELBO
+    substitution and employ variance-reduction practices that stabilize gradients during training. Applied to LLaDA-8B-Instruct,
+    ELBO-KTO yields 65.9% and 62.3% adjusted win rates on kto-mix-14k and UltraFeedback-Binary, respectively, versus the base
+    model under an automatic LLM judge. Across downstream tasks, including GSM8K, MMLU, and additional reasoning/knowledge
+    benchmarks, ELBO-KTO trained on UltraFeedback-Binary performs on par with or better than the base model under identical
+    decoding. This establishes unpaired preference optimization as a viable alternative to pairwise alignment in diffusion
+    LLMs.
+  authors:
+  - Vaibhav Jindal
+  - Hejian Sang
+  - Chun-Mao Lai
+  - Yanning Chen
+  - Zhipeng Wang
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2510.02561
+  title: 'Oracle-RLAIF: An Improved Fine-Tuning Framework for Multi-modal Video Models using Reinforcement Learning from Ranking
+    Feedback'
+  date: '2025-10-02'
+  updated: '2026-06-21'
+  url: https://arxiv.org/abs/2510.02561
+  abstract: Recent advances in large video-language models (VLMs) rely on extensive fine-tuning techniques that strengthen
+    alignment between textual and visual comprehension. Leading pipelines typically pair supervised fine-tuning (SFT) with
+    reinforcement learning from preference data to enhance video comprehension. However, as VLMs scale in parameter size,
+    so does the cost of gathering enough human feedback. To make fine-tuning more cost-effective, recent frameworks explore
+    reinforcement learning with AI feedback (RLAIF), which replace human preference with AI as a judge. Current RLAIF frameworks
+    rely on a specialized reward model trained with video narratives to create calibrated scalar rewards -- an expensive and
+    restrictive pipeline. We propose Oracle-RLAIF, a novel framework that replaces the trained reward model with a more general
+    Oracle ranker which acts as a drop-in model ranking candidate model responses rather than scoring them. Alongside Oracle-RLAIF,
+    we introduce $GRPO_{rank}$, a novel rank-based loss function based on Group Relative Policy Optimization (GRPO) that directly
+    optimizes ordinal feedback with rank-aware advantages. Empirically, we demonstrate that Oracle-RLAIF consistently outperforms
+    leading VLMs using existing fine-tuning methods when evaluated across various video comprehension benchmarks. Oracle-RLAIF
+    paves the path to creating flexible and data-efficient frameworks for aligning large multi-modal video models with reinforcement
+    learning from rank rather than score.
+  authors:
+  - Derek Shi
+  - Ruben Glatt
+  - Christine Klymko
+  - Shubham Mohole
+  - Hongjun Choi
+  - Shashank Kushwaha
+  - Sam Sakla
+  - Felipe Leno da Silva
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  - preference-alignment
+  - reinforcement-learning
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2509.23286
+  title: 'A2D: Any-Order, Any-Step Safety Alignment for Diffusion Language Models'
+  date: '2025-09-27'
+  updated: '2026-02-03'
+  url: https://arxiv.org/abs/2509.23286
+  abstract: 'Diffusion large language models (dLLMs) enable any-order generation, but this flexibility enlarges the attack
+    surface: harmful spans may appear at arbitrary positions, and template-based prefilling attacks such as DIJA bypass response-level
+    refusals. We introduce A2D (Any-Order, Any-Step Defense), a token-level alignment method that aligns dLLMs to emit an
+    [EOS] refusal signal whenever harmful content arises. By aligning safety directly at the token-level under randomized
+    masking, A2D achieves robustness to both any-decoding-order and any-step prefilling attacks under various conditions.
+    It also enables real-time monitoring: dLLMs may begin a response but automatically terminate if unsafe continuation emerges.
+    On safety benchmarks, A2D consistently prevents the generation of harmful outputs, slashing DIJA success rates from over
+    80% to near-zero (1.3% on LLaDA-8B-Instruct, 0.0% on Dream-v0-Instruct-7B), and thresholded [EOS] probabilities allow
+    early rejection, yielding up to 19.3x faster safe termination.'
+  authors:
+  - Wonje Jeung
+  - Sangyeon Yoon
+  - Yoonjun Cho
+  - Dongjae Jeon
+  - Sangwoo Shin
+  - Hyesoo Hong
+  - Albert No
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - preference-alignment
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2406.03816
+  title: 'ReST-MCTS*: LLM Self-Training via Process Reward Guided Tree Search'
+  date: '2024-06-06'
+  updated: '2024-11-18'
+  url: https://arxiv.org/abs/2406.03816
+  abstract: 'Recent methodologies in LLM self-training mostly rely on LLM generating responses and filtering those with correct
+    output answers as training data. This approach often yields a low-quality fine-tuning training set (e.g., incorrect plans
+    or intermediate reasoning). In this paper, we develop a reinforced self-training approach, called ReST-MCTS*, based on
+    integrating process reward guidance with tree search MCTS* for collecting higher-quality reasoning traces as well as per-step
+    value to train policy and reward models. ReST-MCTS* circumvents the per-step manual annotation typically used to train
+    process rewards by tree-search-based reinforcement learning: Given oracle final correct answers, ReST-MCTS* is able to
+    infer the correct process rewards by estimating the probability this step can help lead to the correct answer. These inferred
+    rewards serve dual purposes: they act as value targets for further refining the process reward model and also facilitate
+    the selection of high-quality traces for policy model self-training. We first show that the tree-search policy in ReST-MCTS*
+    achieves higher accuracy compared with prior LLM reasoning baselines such as Best-of-N and Tree-of-Thought, within the
+    same search budget. We then show that by using traces searched by this tree-search policy as training data, we can continuously
+    enhance the three language models for multiple iterations, and outperform other self-training algorithms such as ReST$^\text{EM}$
+    and Self-Rewarding LM. We release all code at https://github.com/THUDM/ReST-MCTS.'
+  authors:
+  - Dan Zhang
+  - Sining Zhoubian
+  - Ziniu Hu
+  - Yisong Yue
+  - Yuxiao Dong
+  - Jie Tang
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  - curated:preference-learning
+  direction_hints:
+  - reasoning-self-improvement
+  - reward-verifiers
+  status: candidate
+  review_priority: 2
+  rule_score: 5
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+  - curated-source:preference-learning
+- id: arxiv:2607.15200
+  title: Mask-Aware Policy Gradients for Diffusion Language Models
+  date: '2026-07-16'
+  updated: '2026-07-16'
+  url: https://arxiv.org/abs/2607.15200
+  abstract: 'Reinforcement learning has proven effective for improving reasoning in large language models, but extending it
+    to Masked Diffusion Language Models (MDLMs) remains challenging due to the intractability of the log-likelihood estimation.
+    Existing approaches approximate this log-likelihood by modeling only the token predictions, ignoring the order in which
+    positions are unmasked during generation. We observe that MDLM generation involves two decisions at each step: what tokens
+    to place at each masked position and which positions to remask. We formalize this as a two-stage action MDP, showing that
+    the policy gradient naturally decomposes into a token term and a masking term. Combining optimization of both terms leads
+    to state-of-the-art outcomes on mathematical reasoning and coding benchmarks, with scores of 87.1% on GSM8K and 53.4%
+    on MBPP.'
+  authors:
+  - Haran Raajesh
+  - Kulin Shah
+  - Adam Klivans
+  - Philipp Krähenbühl
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2607.14522
+  title: A Continuous-Time Reinforcement Learning Framework for Fine-Tuning Discrete Diffusion Models
+  date: '2026-07-16'
+  updated: '2026-07-16'
+  url: https://arxiv.org/abs/2607.14522
+  abstract: We formulate reinforcement learning (RL) in continuous time with discrete state spaces and possibly arbitrary
+    action spaces via a stochastic control approach, where the state dynamics are modeled as a controlled continuous-time
+    Markov chain (CTMC). We consider policy optimization problems and derive the corresponding policy gradient methods, leading
+    to continuous-time variants of proximal policy optimization (PPO) and group relative policy optimization (GRPO). As a
+    primary application, we develop a complete continuous-time RL framework for fine-tuning score-based discrete diffusion
+    models. The proposed framework enables reward-driven optimization without requiring differentiability on the reward signals.
+    In contrast to the existing GRPO-based approaches that only rely on terminal rewards, our formulation allows intermediate
+    reward or advantage signals to be incorporated throughout the denoising trajectory. Importantly, when specialized to masked
+    diffusion models (MDMs), our framework encompasses a rich class of policy parameterizations over the vocabulary simplex
+    with analytically tractable probability ratios, providing a unified perspective on exploration and policy optimization
+    in MDMs. For masked diffusion large language models (dLLMs), we further propose trajectory subsampling techniques to efficiently
+    estimate computationally prohibitive trajectory likelihoods, reducing the computational cost of computing per-position
+    probability ratios. We showcase the effectiveness of our methods on both low-dimensional entropy-regularized optimization
+    problems and RL post-training of dLLMs on mathematical reasoning and coding tasks.
+  authors:
+  - Zikun Zhang
+  - Jiayuan Sheng
+  - David D. Yao
+  - Wenpin Tang
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2607.00208
+  title: 'SLIM-RL: Risk-Budgeted Random-Masking RL for Diffusion LLMs Without Trajectory Slicing'
+  date: '2026-06-30'
+  updated: '2026-06-30'
+  url: https://arxiv.org/abs/2607.00208
+  abstract: Reinforcement learning for diffusion large language models (dLLMs) has largely moved to trajectory-aware methods.
+    The current state of the art, TraceRL, holds that random masking is mismatched with the model's inference trajectory,
+    and it reconstructs that trajectory during training by slicing each rollout into up to K/s trajectory-aligned training
+    samples, a cost that grows with the block size K. We show that this mismatch can be mitigated without reconstructing the
+    trajectory. Our method, SLIM-RL, bounds the commit risk of each rollout step with a tau-budget decoder, reducing aggregate
+    commit risk in the training data. During optimization, SLIM-RL trains on these risk-controlled rollouts with a trace-free
+    random-masking objective that adapts variance-reduction tools, combining sequence-level importance sampling, deterministic
+    quadrature over masking levels under a mean-preserving, monotonically decreasing per-block mask schedule that we introduce.
+    On SDAR-4B, SLIM-RL matches TraceRL's best MATH500 accuracy on only 0.46x its training samples at block size 16, improving
+    over TraceRL by 6.32% on MATH500 and 11.05% on GSM8K under matched dynamic sampling. At block size 4, the 4B SLIM-RL surpasses
+    the larger LLaDA-8B and Dream-7B dLLMs on math, exceeding LLaDA-8B by 10.76% on MATH500 while staying below the autoregressive
+    Qwen2.5-7B. On code, it improves over TraceRL by 4.20% on MBPP and 3.65% on HumanEval. The tau-budget decoder transfers
+    training-free across LLaDA, Dream, and SDAR. The source code is available at https://github.com/laolaorkkkkk/SLIM-RL .
+  authors:
+  - Ruikang Zhao
+  - Zhenting Wang
+  - Han Gao
+  - Ligong Han
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.16342
+  title: 'DACA-GRPO: Denoising-Aware Credit Assignment for Reinforcement Learning in Diffusion Language Models'
+  date: '2026-05-08'
+  updated: '2026-05-08'
+  url: https://arxiv.org/abs/2605.16342
+  abstract: 'Diffusion large language models are a compelling alternative to autoregressive models, yet existing RL methods
+    for diffusion treat all denoising steps as equally important and rely on biased, high-variance likelihood estimates. We
+    identify two fundamental weaknesses: the absence of temporal credit assignment across the denoising trajectory, and the
+    systematic bias of mean-field likelihood estimates used for policy optimization. To address these, we propose Denoising-Aware
+    Credit Assignment for GRPO (DACA-GRPO), a lightweight, plug-and-play enhancement for any GRPO-style trainer. DACA-GRPO
+    introduces two complementary mechanisms: Denoising Progress Scores, which extract per-token importance weights from intermediate
+    predictions at no additional forward cost, and Stratified Masking Likelihood, which partitions token positions into strata
+    so that each token is predicted with most of the sequence as context, reducing the mean-field bias. Applied on top of
+    three GRPO base methods, DACA-GRPO achieves consistent improvements across seven benchmarks spanning mathematical reasoning,
+    code generation, constraint satisfaction, and constrained generation, with gains of up to 5.6pp on math reasoning, 7.4pp
+    on code generation, 36.3pp on constraint satisfaction, and 5.9pp on JSON schema adherence.'
+  authors:
+  - Amin Karimi Monsefi
+  - Dominic Culver
+  - Nikhil Bhendawade
+  - Lokesh Boominathan
+  - Manuel R. Ciosici
+  - Yizhe Zhang
+  - Irina Belousova
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.14696
+  title: 'EponaV2: Driving World Model with Comprehensive Future Reasoning'
+  date: '2026-05-14'
+  updated: '2026-05-14'
+  url: https://arxiv.org/abs/2605.14696
+  abstract: Data scaling plays a pivotal role in the pursuit of general intelligence. However, the prevailing perception-planning
+    paradigm in autonomous driving relies heavily on expensive manual annotations to supervise trajectory planning, which
+    severely limits its scalability. Conversely, although existing perception-free driving world models achieve impressive
+    driving performance, their real-world reasoning ability for planning is solely built on next frame image forecasting.
+    Due to the lack of enough supervision, these models often struggle with comprehensive scene understanding, resulting in
+    unsatisfactory trajectory planning. In this paper, we propose EponaV2, a novel paradigm of driving world models, which
+    achieves high-quality planning with comprehensive future reasoning. Inspired by how human drivers anticipate 3D geometry
+    and semantics, we train our model to forecast more comprehensive future representations, which can be additionally decoded
+    to future geometry and semantic maps. Extracting the 3D and semantic modalities enables our model to deeply understand
+    the surrounding environment, and the future prediction task significantly enhances the real-world reasoning capabilities
+    of EponaV2, ultimately leading to improved trajectory planning. Moreover, inspired by the training recipe of Large Language
+    Models (LLMs), we introduce a flow matching group relative policy optimization mechanism to further improve planning accuracy.
+    The state-of-the-art (SOTA) performances of EponaV2 among perception-free models on three NAVSIM benchmarks (+1.3PDMS,
+    +5.5EPDMS) demonstrate the effectiveness of our methods.
+  authors:
+  - Jiawei Xu
+  - Zhizhou Zhong
+  - Zhijian Shu
+  - Mingkai Jia
+  - Mingxiao Li
+  - Jia-Wang Bian
+  - Qian Zhang
+  - Kaicheng Zhang
+  - Jin Xie
+  - Jian Yang
+  - Wei Yin
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2605.10218
+  title: Relative Score Policy Optimization for Diffusion Language Models
+  date: '2026-05-11'
+  updated: '2026-05-11'
+  url: https://arxiv.org/abs/2605.10218
+  abstract: 'Diffusion large language models (dLLMs) offer a promising route to parallel and efficient text generation, but
+    improving their reasoning ability requires effective post-training. Reinforcement learning with verifiable rewards (RLVR)
+    is a natural choice for this purpose, yet its application to dLLMs is hindered by the absence of tractable sequence-level
+    log-ratios, which are central to standard policy optimization. The lack of tractable sequence-level log-ratios forces
+    existing methods to rely on high-variance ELBO-based approximations, where high verifier rewards can amplify inaccurate
+    score estimates and destabilize RL training. To overcome this issue, we propose \textbf{R}elative \textbf{S}core \textbf{P}olicy
+    \textbf{O}ptimization (RSPO), a simple RLVR method that uses verifiable rewards to calibrate noisy likelihood estimates
+    in dLLMs. The core of our algorithm relies on a key observation: a reward advantage can be interpreted not only as an
+    update direction, but also as a target for the relative log-ratio between the current and reference policies. Accordingly,
+    RSPO calibrates this noisy relative log-ratio estimate by comparing its reward advantage with the reward-implied target
+    relative log-ratio, updating the policy according to the gap between the current estimate and the target rather than the
+    raw advantage alone. Experiments on mathematical reasoning and planning benchmarks show that RSPO yields especially strong
+    gains on planning tasks and competitive mathematical-reasoning performance.'
+  authors:
+  - Zichao Yu
+  - Shengze Xu
+  - Bingqing Jiang
+  - Wenyi Zhang
+  - Difan Zou
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2603.25629
+  title: 'LanteRn: Latent Visual Structured Reasoning'
+  date: '2026-03-26'
+  updated: '2026-07-26'
+  url: https://arxiv.org/abs/2603.25629
+  abstract: 'While language reasoning models excel in many tasks, visual reasoning remains challenging for current large multimodal
+    models (LMMs). As a result, most LMMs default to verbalizing perceptual content into text, a strong limitation for tasks
+    requiring fine-grained spatial and visual understanding. While recent approaches take steps toward thinking with images
+    by invoking tools or generating intermediate images, they either rely on external modules, or incur unnecessary computation
+    by reasoning directly in pixel space. In this paper, we introduce LanteRn, a framework that enables LMMs to interleave
+    language with compact latent visual representations, allowing visual reasoning to occur directly in latent space. LanteRn
+    augments a vision-language transformer with the ability to generate and attend to continuous visual thought embeddings
+    during inference. We train the model in two stages: supervised fine-tuning to ground visual features in latent states,
+    followed by reinforcement learning to align latent reasoning with task-level utility. We evaluate LanteRn on three perception-centric
+    benchmarks (VisCoT, V*, and Blink), observing consistent improvements in visual grounding and fine-grained reasoning.
+    These results suggest that internal latent representations provide a promising direction for more efficient multimodal
+    reasoning.'
+  authors:
+  - André G. Viveiros
+  - Nuno Gonçalves
+  - Matthias Lindemann
+  - André Martins
+  arxiv_categories:
+  - cs.CV
+  - cs.LG
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2603.12554
+  title: Reinforcement Learning for Diffusion LLMs with Entropy-Guided Step Selection and Stepwise Advantages
+  date: '2026-03-13'
+  updated: '2026-05-14'
+  url: https://arxiv.org/abs/2603.12554
+  abstract: Reinforcement learning (RL) has been effective for post-training autoregressive (AR) language models, but extending
+    these methods to diffusion language models (DLMs) is challenging due to intractable sequence-level likelihoods. Existing
+    approaches therefore rely on surrogate likelihoods or heuristic approximations, which can introduce bias and obscure the
+    sequential structure of denoising. We formulate diffusion-based sequence generation as a finite-horizon Markov decision
+    process over the denoising trajectory and derive an exact, unbiased policy gradient that decomposes over denoising steps
+    and is expressed in terms of intermediate advantages, without requiring explicit evaluation of the sequence likelihood.
+    To obtain a practical and compute-efficient estimator, we (i) select denoising steps for policy updates via an entropy-guided
+    approximation bound, and (ii) estimate intermediate advantages using a one-step denoising reward naturally provided by
+    the diffusion model, avoiding costly multi-step rollouts. Experiments on coding and logical reasoning benchmarks demonstrate
+    state-of-the-art results, with strong competitive performance on mathematical reasoning, outperforming existing RL post-training
+    approaches for DLMs. Code is available at https://github.com/vishnutez/egspo-dllm-rl.
+  authors:
+  - Vishnu Teja Kunde
+  - Fatemeh Doudi
+  - Mahdi Farahbakhsh
+  - Dileep Kalathil
+  - Krishna Narayanan
+  - Jean-Francois Chamberland
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2603.01563
+  title: 'LFPO: Likelihood-Free Policy Optimization for Masked Diffusion Models'
+  date: '2026-03-02'
+  updated: '2026-03-02'
+  url: https://arxiv.org/abs/2603.01563
+  abstract: Reinforcement Learning with Verifiable Rewards (RLVR) has achieved remarkable success in improving autoregressive
+    models, especially in domains requiring correctness like mathematical reasoning and code generation. However, directly
+    applying such paradigms to Diffusion Large Language Models (dLLMs) is fundamentally hindered by the intractability of
+    exact likelihood computation, which forces existing methods to rely on high-variance approximations. To bridge this gap,
+    we propose Likelihood-Free Policy Optimization (LFPO), a native framework that maps the concept of vector field flow matching
+    to the discrete token space. Specifically, LFPO formulates alignment as geometric velocity rectification, which directly
+    optimizes denoising logits via contrastive updates. This design effectively bypasses the errors inherent in likelihood
+    approximation, yielding the precise gradient estimation. Furthermore, LFPO enforce consistency by predicting final solutions
+    from intermediate steps, effectively straightening the probability flow to enable high-quality generation with significantly
+    fewer iterations. Extensive experiments demonstrate that LFPO not only outperforms state-of-the-art baselines on code
+    and reasoning benchmarks but also accelerates inference by approximately 20% through reduced diffusion steps.
+  authors:
+  - Chenxing Wei
+  - Jiazhen Kang
+  - Hong Wang
+  - Jianqing Zhang
+  - Hao Jiang
+  - Xiaolong Xu
+  - Ningyuan Sun
+  - Ying He
+  - F. Richard Yu
+  - Yao Shu
+  - Bo Jiang
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2602.21952
+  title: 'MindDriver: Introducing Progressive Multimodal Reasoning for Autonomous Driving'
+  date: '2026-02-25'
+  updated: '2026-02-25'
+  url: https://arxiv.org/abs/2602.21952
+  abstract: Vision-Language Models (VLM) exhibit strong reasoning capabilities, showing promise for end-to-end autonomous
+    driving systems. Chain-of-Thought (CoT), as VLM's widely used reasoning strategy, is facing critical challenges. Existing
+    textual CoT has a large gap between text semantic space and trajectory physical space. Although the recent approach utilizes
+    future image to replace text as CoT process, it lacks clear planning-oriented objective guidance to generate images with
+    accurate scene evolution. To address these, we innovatively propose MindDriver, a progressive multimodal reasoning framework
+    that enables VLM to imitate human-like progressive thinking for autonomous driving. MindDriver presents semantic understanding,
+    semantic-to-physical space imagination, and physical-space trajectory planning. To achieve aligned reasoning processes
+    in MindDriver, we develop a feedback-guided automatic data annotation pipeline to generate aligned multimodal reasoning
+    training data. Furthermore, we develop a progressive reinforcement fine-tuning method to optimize the alignment through
+    progressive high- level reward-based learning. MindDriver demonstrates superior performance in both nuScences open-loop
+    and Bench2Drive closed-loop evaluation. Codes are available at https://github.com/hotdogcheesewhite/MindDriver.
+  authors:
+  - Lingjun Zhang
+  - Yujian Yuan
+  - Changjie Wu
+  - Xinyuan Chang
+  - Xin Cai
+  - Shuang Zeng
+  - Linzhe Shi
+  - Sijin Wang
+  - Hang Zhang
+  - Mu Xu
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2602.21172
+  title: 'NoRD: A Data-Efficient Vision-Language-Action Model that Drives without Reasoning'
+  date: '2026-02-24'
+  updated: '2026-06-05'
+  url: https://arxiv.org/abs/2602.21172
+  abstract: 'Vision-Language-Action (VLA) models are advancing autonomous driving by replacing modular pipelines with unified
+    end-to-end architectures. However, current VLAs face two expensive requirements: (1) massive dataset collection, and (2)
+    dense reasoning annotations. In this work, we address both challenges with NORD (No Reasoning for Driving). Compared to
+    existing VLAs, NORD achieves competitive performance while being fine-tuned on <60% of the data and no reasoning annotations,
+    resulting in 3x fewer tokens. We identify that standard Group Relative Policy Optimization (GRPO) fails to yield significant
+    improvements when applied to policies trained on such small, reasoning-free datasets. We show that this limitation stems
+    from difficulty bias, which disproportionately penalizes reward signals from scenarios that produce high-variance rollouts
+    within GRPO. NORD overcomes this by incorporating Dr. GRPO, a recent algorithm designed to mitigate difficulty bias in
+    LLMs. As a result, NORD achieves competitive performance on Waymo and NAVSIM with a fraction of the training data and
+    no reasoning overhead, enabling more efficient autonomous systems. Website: https://nord-vla-ai.github.io/'
+  authors:
+  - Ishaan Rawal
+  - Shubh Gupta
+  - Yihan Hu
+  - Wei Zhan
+  arxiv_categories:
+  - cs.AI
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2602.06462
+  title: Diffusion-State Policy Optimization for Masked Diffusion Language Models
+  date: '2026-02-06'
+  updated: '2026-05-19'
+  url: https://arxiv.org/abs/2602.06462
+  abstract: Masked diffusion language models generate text through iterative masked-token filling, but terminal-only rewards
+    on final completions provide coarse credit assignment for the intermediate filling decisions that shape the generation
+    process. We propose Diffusion-State Policy Optimization (DiSPO), a plug-in credit-assignment layer that directly optimizes
+    intermediate filling decisions. At selected intermediate masked states, DiSPO branches by resampling the currently masked
+    positions from rollout-cached logits, scores the resulting completions, and updates only the newly filled tokens, requiring
+    no additional multi-step diffusion rollouts or optimizer steps. We formalize a fixed-state objective for branched completions
+    and derive a policy-gradient estimator that reuses the same rollouts as terminal-feedback policy optimization. Experiments
+    on LLaDA-8B-Instruct show that DiSPO consistently improves terminal-feedback baselines, including diffu-GRPO and SPG,
+    on math and planning benchmarks under matched rollout compute and optimizer steps, supporting its use as a general plug-in
+    for masked diffusion policy optimization. Our project page is available at https://daioba.github.io/dispo .
+  authors:
+  - Daisuke Oba
+  - Hiroki Furuta
+  - Naoaki Okazaki
+  arxiv_categories:
+  - cs.CL
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2601.15165
+  title: 'The Flexibility Trap: Rethinking the Value of Arbitrary Order in Diffusion Language Models'
+  date: '2026-01-21'
+  updated: '2026-06-08'
+  url: https://arxiv.org/abs/2601.15165
+  abstract: 'Diffusion Large Language Models (dLLMs) break the rigid left-to-right constraint of traditional LLMs, enabling
+    token generation in arbitrary orders. Intuitively, this flexibility implies a solution space that strictly supersets the
+    fixed autoregressive trajectory, theoretically unlocking superior reasoning potential. However, in this paper, we find
+    that for general reasoning tasks (e.g., mathematics and coding), arbitrary order generation may in fact limit the reasoning
+    potential of dLLMs. We observe that dLLMs tend to exploit this order flexibility to bypass high-uncertainty tokens that
+    are crucial for exploration, which can lead to a premature collapse of solution coverage. This observation motivates a
+    rethink of RL approaches for dLLMs, where considerable complexities, such as handling combinatorial trajectories and intractable
+    likelihoods, are often devoted to preserving this flexibility. We show that effective reasoning can be elicited by simply
+    forgoing arbitrary order and applying standard Group Relative Policy Optimization (GRPO) instead. Our approach, JustGRPO,
+    is minimalist yet surprisingly effective (e.g., 89.1% accuracy on GSM8K) while fully retaining the parallel decoding ability
+    of dLLMs. Project page: https://nzl-thu.github.io/the-flexibility-trap'
+  authors:
+  - Zanlin Ni
+  - Shenzhi Wang
+  - Yang Yue
+  - Tianyu Yu
+  - Weilin Zhao
+  - Yeguo Hua
+  - Tianyi Chen
+  - Jun Song
+  - Cheng Yu
+  - Bo Zheng
+  - Gao Huang
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2605.12625
+  title: Driving Intents Amplify Planning-Oriented Reinforcement Learning
+  date: '2026-05-12'
+  updated: '2026-05-14'
+  url: https://arxiv.org/abs/2605.12625
+  abstract: 'Continuous-action policies trained on a single demonstrated trajectory per scene suffer from mode collapse: samples
+    cluster around the demonstrated maneuver and the policy cannot represent semantically distinct alternatives. Under preference-based
+    evaluation, this caps best-of-N performance -- even oracle selection cannot recover what the sampling distribution does
+    not contain. We introduce DIAL, a two-stage Driving-Intent-Amplified reinforcement Learning framework for preference-aligned
+    continuous-action driving policies. In the first stage, DIAL conditions the flow-matching action head on a discrete intent
+    label with classifier-free guidance (CFG), which expands the sampling distribution along distinct maneuver modes and breaks
+    single-demonstration mode collapse. In the second stage, DIAL carries this expanded distribution into preference RL through
+    multi-intent GRPO, which spans all intent classes within every preference group and prevents fine-tuning from re-collapsing
+    around the currently preferred mode. Instantiated for end-to-end driving with eight rule-derived intents and evaluated
+    on WOD-E2E: competitive Vision-to-Action (VA) and Vision-Language-Action (VLA) Supervised Finetuning (SFT) baselines plateau
+    below the human-driven demonstration at best-of-128, with the strongest prior (RAP) capping at Rater Feedback Score (RFS)
+    8.5 even with best-of-64; intent-CFG sampling lifts this ceiling to RFS 9.14 at best-of-128, surpassing both the prior
+    best (RAP 8.5) and the human-driven demonstration (8.13) for the first time; and multi-intent GRPO improves held-out RFS
+    from 7.681 to 8.211, while every single-intent baseline peaks lower and degrades by training end. These results suggest
+    that the bottleneck of preference RL on continuous-action policies trained from demons'
+  authors:
+  - Hengtong Lu
+  - Victor Shea-Jay Huang
+  - Chengmin Yang
+  - Pengfei Jing
+  - Jifeng Dai
+  - Yan Xie
+  - Benjin Zhu
+  arxiv_categories:
+  - cs.RO
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2604.15308
+  title: 'RAD-2: Scaling Reinforcement Learning in a Generator-Discriminator Framework'
+  date: '2026-04-16'
+  updated: '2026-04-16'
+  url: https://arxiv.org/abs/2604.15308
+  abstract: High-level autonomous driving requires motion planners capable of modeling multimodal future uncertainties while
+    remaining robust in closed-loop interactions. Although diffusion-based planners are effective at modeling complex trajectory
+    distributions, they often suffer from stochastic instabilities and the lack of corrective negative feedback when trained
+    purely with imitation learning. To address these issues, we propose RAD-2, a unified generator-discriminator framework
+    for closed-loop planning. Specifically, a diffusion-based generator is used to produce diverse trajectory candidates,
+    while an RL-optimized discriminator reranks these candidates according to their long-term driving quality. This decoupled
+    design avoids directly applying sparse scalar rewards to the full high-dimensional trajectory space, thereby improving
+    optimization stability. To further enhance reinforcement learning, we introduce Temporally Consistent Group Relative Policy
+    Optimization, which exploits temporal coherence to alleviate the credit assignment problem. In addition, we propose On-policy
+    Generator Optimization, which converts closed-loop feedback into structured longitudinal optimization signals and progressively
+    shifts the generator toward high-reward trajectory manifolds. To support efficient large-scale training, we introduce
+    BEV-Warp, a high-throughput simulation environment that performs closed-loop evaluation directly in Bird's-Eye View feature
+    space via spatial warping. RAD-2 reduces the collision rate by 56% compared with strong diffusion-based planners. Real-world
+    deployment further demonstrates improved perceived safety and driving smoothness in complex urban traffic.
+  authors:
+  - Hao Gao
+  - Shaoyu Chen
+  - Yifan Zhu
+  - Yuehao Song
+  - Wenyu Liu
+  - Qian Zhang
+  - Xinggang Wang
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.28116
+  title: '$AutoDrive\text{-}P^3$: Unified Chain of Perception-Prediction-Planning Thought via Reinforcement Fine-Tuning'
+  date: '2026-03-30'
+  updated: '2026-03-30'
+  url: https://arxiv.org/abs/2603.28116
+  abstract: 'Vision-language models (VLMs) are increasingly being adopted for end-to-end autonomous driving systems due to
+    their exceptional performance in handling long-tail scenarios. However, current VLM-based approaches suffer from two major
+    limitations: 1) Some VLMs directly output planning results without chain-of-thought (CoT) reasoning, bypassing crucial
+    perception and prediction stages which creates a significant domain gap and compromises decision-making capability; 2)
+    Other VLMs can generate outputs for perception, prediction, and planning tasks but employ a fragmented decision-making
+    approach where these modules operate separately, leading to a significant lack of synergy that undermines true planning
+    performance. To address these limitations, we propose ${AutoDrive\text{-}P^3}$, a novel framework that seamlessly integrates
+    $\textbf{P}$erception, $\textbf{P}$rediction, and $\textbf{P}$lanning through structured reasoning. We introduce the ${P^3\text{-}CoT}$
+    dataset to facilitate coherent reasoning and propose ${P^3\text{-}GRPO}$, a hierarchical reinforcement learning algorithm
+    that provides progressive supervision across all three tasks. Specifically, ${AutoDrive\text{-}P^3}$ progressively generates
+    CoT reasoning and answers for perception, prediction, and planning, where perception provides essential information for
+    subsequent prediction and planning, while both perception and prediction collectively contribute to the final planning
+    decisions, enabling safer and more interpretable autonomous driving. Additionally, to balance inference efficiency with
+    performance, we introduce dual thinking modes: detailed thinking and fast thinking. Extensive experiments on both open-loop
+    (nuScenes) and closed-loop (NAVSIMv1/v2) benchmarks demonstrate that our approach achieves state-of'
+  authors:
+  - Yuqi Ye
+  - Zijian Zhang
+  - Junhong Lin
+  - Shangkun Sun
+  - Changhao Peng
+  - Wei Gao
+  arxiv_categories:
+  - cs.RO
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - reinforcement-learning
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.24587
+  title: 'DreamerAD: Efficient Reinforcement Learning via Latent World Model for Autonomous Driving'
+  date: '2026-03-25'
+  updated: '2026-04-01'
+  url: https://arxiv.org/abs/2603.24587
+  abstract: 'We introduce DreamerAD, the first latent world model framework that enables efficient reinforcement learning
+    for autonomous driving by compressing diffusion sampling from 100 steps to 1 - achieving 80x speedup while maintaining
+    visual interpretability. Training RL policies on real-world driving data incurs prohibitive costs and safety risks. While
+    existing pixel-level diffusion world models enable safe imagination-based training, they suffer from multi-step diffusion
+    inference latency (2s/frame) that prevents high-frequency RL interaction. Our approach leverages denoised latent features
+    from video generation models through three key mechanisms: (1) shortcut forcing that reduces sampling complexity via recursive
+    multi-resolution step compression, (2) an autoregressive dense reward model operating directly on latent representations
+    for fine-grained credit assignment, and (3) Gaussian vocabulary sampling for GRPO that constrains exploration to physically
+    plausible trajectories. DreamerAD achieves 87.7 EPDMS on NavSim v2, establishing state-of-the-art performance and demonstrating
+    that latent-space RL is effective for autonomous driving.'
+  authors:
+  - Pengxuan Yang
+  - Yupeng Zheng
+  - Deheng Qian
+  - Zebin Xing
+  - Qichao Zhang
+  - Linbo Wang
+  - Yichen Zhang
+  - Shaoyu Guo
+  - Zhongpu Xia
+  - Qiang Chen
+  - Junyu Han
+  - Lingyun Xu
+  - Yifeng Pan
+  - Dongbin Zhao
+  arxiv_categories:
+  - cs.LG
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.13842
+  title: 'Fine-tuning is Not Enough: A Parallel Framework for Collaborative Imitation and Reinforcement Learning in End-to-end
+    Autonomous Driving'
+  date: '2026-03-14'
+  updated: '2026-04-10'
+  url: https://arxiv.org/abs/2603.13842
+  abstract: 'End-to-end autonomous driving is typically built upon imitation learning (IL), yet its performance is constrained
+    by the quality of human demonstrations. To overcome this limitation, recent methods incorporate reinforcement learning
+    (RL) through sequential fine-tuning. However, such a paradigm remains suboptimal: sequential RL fine-tuning can introduce
+    policy drift and often leads to a performance ceiling due to its dependence on the pretrained IL policy. To address these
+    issues, we propose PaIR-Drive, a general Parallel framework for collaborative Imitation and Reinforcement learning in
+    end-to-end autonomous driving. During training, PaIR-Drive separates IL and RL into two parallel branches with conflict-free
+    training objectives, enabling fully collaborative optimization. This design eliminates the need to retrain RL when applying
+    a new IL policy. During inference, RL leverages the IL policy to further optimize the final plan, allowing performance
+    beyond prior knowledge of IL. Furthermore, we introduce a tree-structured trajectory neural sampler to group relative
+    policy optimization (GRPO) in the RL branch, which enhances exploration capability. Extensive analysis on NAVSIMv1 and
+    v2 benchmark demonstrates that PaIR-Drive achieves Competitive performance of 91.2 PDMS and 87.9 EPDMS, building upon
+    Transfuser and DiffusionDrive IL baselines. PaIR-Drive consistently outperforms existing RL fine-tuning methods, and could
+    even correct human experts'' suboptimal behaviors. Qualitative results further confirm that PaIR-Drive can effectively
+    explore and generate high-quality trajectories.'
+  authors:
+  - Zhexi Lian
+  - Haoran Wang
+  - Xuerun Yan
+  - Weimeng Lin
+  - Xianhong Zhang
+  - Yongyu Chen
+  - Jia Hu
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - distillation
+  - embodied-vla
+  - reinforcement-learning
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2602.22661
+  title: 'dLLM: Simple Diffusion Language Modeling'
+  date: '2026-02-26'
+  updated: '2026-02-26'
+  url: https://arxiv.org/abs/2602.22661
+  abstract: Although diffusion language models (DLMs) are evolving quickly, many recent models converge on a set of shared
+    components. These components, however, are distributed across ad-hoc research codebases or lack transparent implementations,
+    making them difficult to reproduce or extend. As the field accelerates, there is a clear need for a unified framework
+    that standardizes these common components while remaining flexible enough to support new methods and architectures. To
+    address this gap, we introduce dLLM, an open-source framework that unifies the core components of diffusion language modeling
+    -- training, inference, and evaluation -- and makes them easy to customize for new designs. With dLLM, users can reproduce,
+    finetune, deploy, and evaluate open-source large DLMs such as LLaDA and Dream through a standardized pipeline. The framework
+    also provides minimal, reproducible recipes for building small DLMs from scratch with accessible compute, including converting
+    any BERT-style encoder or autoregressive LM into a DLM. We also release the checkpoints of these small DLMs to make DLMs
+    more accessible and accelerate future research.
+  authors:
+  - Zhanhui Zhou
+  - Lingjie Chen
+  - Hanghang Tong
+  - Dawn Song
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reinforcement-learning
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2602.21992
+  title: 'PanoEnv: Exploring 3D Spatial Intelligence in Panoramic Environments with Reinforcement Learning'
+  date: '2026-02-25'
+  updated: '2026-02-25'
+  url: https://arxiv.org/abs/2602.21992
+  abstract: '360 panoramic images are increasingly used in virtual reality, autonomous driving, and robotics for holistic
+    scene understanding. However, current Vision-Language Models (VLMs) struggle with 3D spatial reasoning on Equirectangular
+    Projection (ERP) images due to geometric distortion and limited 3D supervision. We introduce PanoEnv, a large-scale VQA
+    benchmark built from synthetic 3D environments, containing 14.8K questions across five categories (e.g., relative position,
+    volume comparison) grounded in accurate 3D annotations including depth, segmentation, and bounding boxes. Benchmarking
+    14 state-of-the-art VLMs reveals limited 3D understanding, achieving only 49.34% overall accuracy and 8.36% on open-ended
+    (OE) questions. To enhance 3D reasoning, we propose a reinforcement learning post-training framework based on Group Relative
+    Policy Optimization (GRPO) with a ground-truth-guided reward that incorporates five geometry-aware strategies such as
+    distance tolerance and spatial consistency. A two-stage curriculum further mitigates catastrophic forgetting: Stage 1
+    trains on structured tasks (true/false and multiple choice), and Stage 2 fine-tunes on mixed open-ended data to improve
+    generalization. Our 7B model achieves new state-of-the-art performance, improving overall accuracy to 52.93% (+3.59%)
+    and open-ended accuracy to 14.83% while maintaining structured-task performance. It also achieves top semantic evaluation
+    scores (Q-Score 6.24, P-Score 5.95), surpassing 32B models. These results demonstrate that PanoEnv-QA and our curriculum-based
+    RL framework effectively instill 3D spatial intelligence in VLMs for omnidirectional perception.'
+  authors:
+  - Zekai Lin
+  - Xu Zheng
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2602.10458
+  title: 'Found-RL: foundation model-enhanced reinforcement learning for autonomous driving'
+  date: '2026-02-11'
+  updated: '2026-02-11'
+  url: https://arxiv.org/abs/2602.10458
+  abstract: 'Reinforcement Learning (RL) has emerged as a dominant paradigm for end-to-end autonomous driving (AD). However,
+    RL suffers from sample inefficiency and a lack of semantic interpretability in complex scenarios. Foundation Models, particularly
+    Vision-Language Models (VLMs), can mitigate this by offering rich, context-aware knowledge, yet their high inference latency
+    hinders deployment in high-frequency RL training loops. To bridge this gap, we present Found-RL, a platform tailored to
+    efficiently enhance RL for AD using foundation models. A core innovation is the asynchronous batch inference framework,
+    which decouples heavy VLM reasoning from the simulation loop, effectively resolving latency bottlenecks to support real-time
+    learning. We introduce diverse supervision mechanisms: Value-Margin Regularization (VMR) and Advantage-Weighted Action
+    Guidance (AWAG) to effectively distill expert-like VLM action suggestions into the RL policy. Additionally, we adopt high-throughput
+    CLIP for dense reward shaping. We address CLIP''s dynamic blindness via Conditional Contrastive Action Alignment, which
+    conditions prompts on discretized speed/command and yields a normalized, margin-based bonus from context-specific action-anchor
+    scoring. Found-RL provides an end-to-end pipeline for fine-tuned VLM integration and shows that a lightweight RL model
+    can achieve near-VLM performance compared with billion-parameter VLMs while sustaining real-time inference (approx. 500
+    FPS). Code, data, and models will be publicly available at https://github.com/ys-qu/found-rl.'
+  authors:
+  - Yansong Qu
+  - Zihao Sheng
+  - Zilin Huang
+  - Jiancong Chen
+  - Yuhao Luo
+  - Tianyi Wang
+  - Yiheng Feng
+  - Samuel Labi
+  - Sikai Chen
+  arxiv_categories:
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - distillation
+  - embodied-vla
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2601.04714
+  title: 'ThinkDrive: Chain-of-Thought Guided Progressive Reinforcement Learning Fine-Tuning for Autonomous Driving'
+  date: '2026-01-08'
+  updated: '2026-01-08'
+  url: https://arxiv.org/abs/2601.04714
+  abstract: With the rapid advancement of large language models (LLMs) technologies, their application in the domain of autonomous
+    driving has become increasingly widespread. However, existing methods suffer from unstructured reasoning, poor generalization,
+    and misalignment with human driving intent. While Chain-of-Thought (CoT) reasoning enhances decision transparency, conventional
+    supervised fine-tuning (SFT) fails to fully exploit its potential, and reinforcement learning (RL) approaches face instability
+    and suboptimal reasoning depth. We propose ThinkDrive, a CoT guided progressive RL fine-tuning framework for autonomous
+    driving that synergizes explicit reasoning with difficulty-aware adaptive policy optimization. Our method employs a two-stage
+    training strategy. First, we perform SFT using CoT explanations. Then, we apply progressive RL with a difficulty-aware
+    adaptive policy optimizer that dynamically adjusts learning intensity based on sample complexity. We evaluate our approach
+    on a public dataset. The results show that ThinkDrive outperforms strong RL baselines by 1.45%, 1.95%, and 1.01% on exam,
+    easy-exam, and accuracy, respectively. Moreover, a 2B-parameter model trained with our method surpasses the much larger
+    GPT-4o by 3.28% on the exam metric.
+  authors:
+  - Chang Zhao
+  - Zheming Yang
+  - Yunqing Hu
+  - Qi Guo
+  - Zijian Wang
+  - Pengcheng Li
+  - Wen Ji
+  arxiv_categories:
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - reinforcement-learning
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2512.22234
+  title: 'DiRL: An Efficient Post-Training Framework for Diffusion Language Models'
+  date: '2025-12-23'
+  updated: '2026-01-06'
+  url: https://arxiv.org/abs/2512.22234
+  abstract: Diffusion Language Models (dLLMs) have emerged as promising alternatives to Auto-Regressive (AR) models. While
+    recent efforts have validated their pre-training potential and accelerated inference speeds, the post-training landscape
+    for dLLMs remains underdeveloped. Existing methods suffer from computational inefficiency and objective mismatches between
+    training and inference, severely limiting performance on complex reasoning tasks such as mathematics. To address this,
+    we introduce DiRL, an efficient post-training framework that tightly integrates FlexAttention-accelerated blockwise training
+    with LMDeploy-optimized inference. This architecture enables a streamlined online model update loop, facilitating efficient
+    two-stage post-training (Supervised Fine-Tuning followed by Reinforcement Learning). Building on this framework, we propose
+    DiPO, the first unbiased Group Relative Policy Optimization (GRPO) implementation tailored for dLLMs. We validate our
+    approach by training DiRL-8B-Instruct on high-quality math data. Our model achieves state-of-the-art math performance
+    among dLLMs and surpasses comparable models in the Qwen2.5 series on several benchmarks.
+  authors:
+  - Ying Zhu
+  - Jiaxin Wan
+  - Xiaoran Liu
+  - Siyang He
+  - Qiqi Wang
+  - Xu Guo
+  - Tianyi Liang
+  - Zengfeng Huang
+  - Ziwei He
+  - Xipeng Qiu
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.14044
+  title: 'OmniDrive-R1: Reinforcement-driven Interleaved Multi-modal Chain-of-Thought for Trustworthy Vision-Language Autonomous
+    Driving'
+  date: '2025-12-16'
+  updated: '2026-04-30'
+  url: https://arxiv.org/abs/2512.14044
+  abstract: 'The deployment of Vision-Language Models (VLMs) in safety-critical domains like autonomous driving (AD) is critically
+    hindered by reliability failures, most notably object hallucination. This failure stems from their reliance on ungrounded,
+    text-based Chain-of-Thought (CoT) reasoning. While existing multi-modal CoT approaches attempt mitigation, they suffer
+    from two fundamental flaws: (1) decoupled perception and reasoning stages that prevent end-to-end joint optimization,
+    and (2) reliance on expensive, dense localization labels. Thus we introduce OmniDrive-R1, an end-to-end VLM framework
+    designed for autonomous driving, which unifies perception and reasoning through an interleaved Multi-modal Chain-of-Thought
+    (iMCoT) mechanism. Our core innovation is an Reinforcement-driven visual grounding capability, enabling the model to autonomously
+    direct its attention and "zoom in" on critical regions for fine-grained analysis. This capability is enabled by our pure
+    two-stage reinforcement learning training pipeline and Clip-GRPO algorithm. Crucially, Clip-GRPO introduces an annotation-free,
+    process-based grounding reward. This reward not only eliminates the need for dense labels but also circumvents the instability
+    of external tool calls by enforcing real-time cross-modal consistency between the visual focus and the textual reasoning.
+    Extensive experiments on DriveLMM-o1 demonstrate our model''s significant improvements. Compared to the baseline Qwen2.5VL-7B,
+    OmniDrive-R1 improves the overall reasoning score from 51.77% to 80.35%, and the final answer accuracy from 37.81% to
+    73.62%.'
+  authors:
+  - Zhenguo Zhang
+  - Haohan Zheng
+  - Yishen Wang
+  - Le Xu
+  - Tianchen Deng
+  - Xuefeng Chen
+  - Qu Chen
+  - Bo Zhang
+  - Wuxiong Huang
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2512.11872
+  title: 'WAM-Diff: A Masked Diffusion VLA Framework with MoE and Online Reinforcement Learning for Autonomous Driving'
+  date: '2025-12-06'
+  updated: '2025-12-06'
+  url: https://arxiv.org/abs/2512.11872
+  abstract: 'End-to-end autonomous driving systems based on vision-language-action (VLA) models integrate multimodal sensor
+    inputs and language instructions to generate planning and control signals. While autoregressive large language models
+    and continuous diffusion policies are prevalent, the potential of discrete masked diffusion for trajectory generation
+    remains largely unexplored. This paper presents WAM-Diff, a VLA framework that employs masked diffusion to iteratively
+    refine a discrete sequence representing future ego-trajectories. Our approach features three key innovations: a systematic
+    adaptation of masked diffusion for autonomous driving that supports flexible, non-causal decoding orders; scalable model
+    capacity via a sparse MoE architecture trained jointly on motion prediction and driving-oriented visual question answering
+    (VQA); and online reinforcement learning using Group Sequence Policy Optimization (GSPO) to optimize sequence-level driving
+    rewards. Remarkably, our model achieves 91.0 PDMS on NAVSIM-v1 and 89.7 EPDMS on NAVSIM-v2, demonstrating the effectiveness
+    of masked diffusion for autonomous driving. The approach provides a promising alternative to autoregressive and diffusion-based
+    policies, supporting scenario-aware decoding strategies for trajectory generation. The code for this paper will be released
+    publicly at: https://github.com/fudan-generative-vision/WAM-Diff'
+  authors:
+  - Mingwang Xu
+  - Jiahao Cui
+  - Feipeng Cai
+  - Hanlin Shang
+  - Zhihao Zhu
+  - Shan Luan
+  - Yifang Xu
+  - Neng Zhang
+  - Yaoyi Li
+  - Jia Cai
+  - Siyu Zhu
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - generative-media
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2211.14275
+  title: Solving math word problems with process- and outcome-based feedback
+  date: '2022-11-25'
+  updated: '2022-11-25'
+  url: https://arxiv.org/abs/2211.14275
+  abstract: 'Recent work has shown that asking language models to generate reasoning steps improves performance on many reasoning
+    tasks. When moving beyond prompting, this raises the question of how we should supervise such models: outcome-based approaches
+    which supervise the final result, or process-based approaches which supervise the reasoning process itself? Differences
+    between these approaches might naturally be expected not just in final-answer errors but also in reasoning errors, which
+    can be difficult to detect and are problematic in many real-world domains such as education. We run the first comprehensive
+    comparison between process- and outcome-based approaches trained on a natural language task, GSM8K. We find that pure
+    outcome-based supervision produces similar final-answer error rates with less label supervision. However, for correct
+    reasoning steps we find it necessary to use process-based supervision or supervision from learned reward models that emulate
+    process-based feedback. In total, we improve the previous best results from 16.8% $\to$ 12.7% final-answer error and 14.0%
+    $\to$ 3.4% reasoning error among final-answer-correct solutions.'
+  authors:
+  - Jonathan Uesato
+  - Nate Kushman
+  - Ramana Kumar
+  - Francis Song
+  - Noah Siegel
+  - Lisa Wang
+  - Antonia Creswell
+  - Geoffrey Irving
+  - Irina Higgins
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  - curated:preference-learning
+  direction_hints:
+  - reward-verifiers
+  status: candidate
+  review_priority: 2
+  rule_score: 5
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+  - curated-source:preference-learning
+- id: arxiv:2603.25968
+  title: Neuro-Cognitive Reward Modeling for Human-Centered Autonomous Vehicle Control
+  date: '2026-03-26'
+  updated: '2026-03-31'
+  url: https://arxiv.org/abs/2603.25968
+  abstract: 'Recent advancements in computer vision have accelerated the development of autonomous driving. Despite these
+    advancements, training machines to drive in a way that aligns with human expectations remains a significant challenge.
+    Human factors are still essential, as humans possess a sophisticated cognitive system capable of rapidly interpreting
+    scene information and making accurate decisions. Aligning machine with human intent has been explored with Reinforcement
+    Learning with Human Feedback (RLHF). Conventional RLHF methods rely on collecting human preference data by manually ranking
+    generated outputs, which is time-consuming and indirect. In this work, we propose an electroencephalography (EEG)-guided
+    decision-making framework to incorporate human cognitive insights without behaviour response interruption into reinforcement
+    learning (RL) for autonomous driving. We collected EEG signals from 20 participants in a realistic driving simulator and
+    analyzed event-related potentials (ERP) in response to sudden environmental changes. Our proposed framework employs a
+    neural network to predict the strength of ERP based on the cognitive information from visual scene information. Moreover,
+    we explore the integration of such cognitive information into the reward signal of the RL algorithm. Experimental results
+    show that our framework can improve the collision avoidance ability of the RL algorithm, highlighting the potential of
+    neuro-cognitive feedback in enhancing autonomous driving systems. Our project page is: https://alex95gogo.github.io/Cognitive-Reward/.'
+  authors:
+  - Zhuoli Zhuang
+  - Yu-Cheng Chang
+  - Yu-Kai Wang
+  - Thomas Do
+  - Chin-Teng Lin
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2505.20325
+  title: 'Guided by Gut: Efficient Test-Time Scaling with Reinforced Intrinsic Confidence'
+  date: '2025-05-23'
+  updated: '2025-05-23'
+  url: https://arxiv.org/abs/2505.20325
+  abstract: Test-Time Scaling (TTS) methods for enhancing Large Language Model (LLM) reasoning often incur substantial computational
+    costs, primarily due to extensive reliance on external Process Reward Models (PRMs) or sampling methods like Best-of-N
+    (BoN). This paper introduces Guided by Gut (GG), an efficient self-guided TTS framework that achieves PRM-level performance
+    without costly external verifier models. Our method employs a lightweight tree search guided solely by intrinsic LLM signals,
+    token-level confidence and step novelty. One critical innovation is improving the reliability of internal confidence estimates
+    via a targeted reinforcement learning fine-tuning phase. Empirical evaluations on challenging mathematical reasoning benchmarks
+    demonstrate that GG enables smaller models (e.g., 1.5B parameters) to achieve accuracy matching or surpassing significantly
+    larger models (e.g., 32B-70B parameters), while reducing GPU memory usage by up to 10x. Compared to PRM-based methods,
+    GG achieves comparable accuracy with 8x faster inference speeds and 4-5x lower memory usage. Additionally, GG reduces
+    KV cache memory usage by approximately 50% compared to the BoN strategy, facilitating more efficient and practical deployment
+    of TTS techniques.
+  authors:
+  - Amirhosein Ghasemabadi
+  - Keith G. Mills
+  - Baochun Li
+  - Di Niu
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2504.13125
+  title: 'LLMs Meet Finance: Fine-Tuning Foundation Models for the Open FinLLM Leaderboard'
+  date: '2025-04-17'
+  updated: '2025-04-17'
+  url: https://arxiv.org/abs/2504.13125
+  abstract: This paper investigates the application of large language models (LLMs) to financial tasks. We fine-tuned foundation
+    models using the Open FinLLM Leaderboard as a benchmark. Building on Qwen2.5 and Deepseek-R1, we employed techniques including
+    supervised fine-tuning (SFT), direct preference optimization (DPO), and reinforcement learning (RL) to enhance their financial
+    capabilities. The fine-tuned models demonstrated substantial performance gains across a wide range of financial tasks.
+    Moreover, we measured the data scaling law in the financial domain. Our work demonstrates the potential of large language
+    models (LLMs) in financial applications.
+  authors:
+  - Varun Rao
+  - Youran Sun
+  - Mahendra Kumar
+  - Tejas Mutneja
+  - Agastya Mukherjee
+  - Haizhao Yang
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reward-verifiers
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2503.10291
+  title: 'VisualPRM: An Effective Process Reward Model for Multimodal Reasoning'
+  date: '2025-03-13'
+  updated: '2025-03-13'
+  url: https://arxiv.org/abs/2503.10291
+  abstract: We introduce VisualPRM, an advanced multimodal Process Reward Model (PRM) with 8B parameters, which improves the
+    reasoning abilities of existing Multimodal Large Language Models (MLLMs) across different model scales and families with
+    Best-of-N (BoN) evaluation strategies. Specifically, our model improves the reasoning performance of three types of MLLMs
+    and four different model scales. Even when applied to the highly capable InternVL2.5-78B, it achieves a 5.9-point improvement
+    across seven multimodal reasoning benchmarks. Experimental results show that our model exhibits superior performance compared
+    to Outcome Reward Models and Self-Consistency during BoN evaluation. To facilitate the training of multimodal PRMs, we
+    construct a multimodal process supervision dataset VisualPRM400K using an automated data pipeline. For the evaluation
+    of multimodal PRMs, we propose VisualProcessBench, a benchmark with human-annotated step-wise correctness labels, to measure
+    the abilities of PRMs to detect erroneous steps in multimodal reasoning tasks. We hope that our work can inspire more
+    future research and contribute to the development of MLLMs. Our model, data, and benchmark are released in https://internvl.github.io/blog/2025-03-13-VisualPRM/.
+  authors:
+  - Weiyun Wang
+  - Zhangwei Gao
+  - Lianjie Chen
+  - Zhe Chen
+  - Jinguo Zhu
+  - Xiangyu Zhao
+  - Yangzhou Liu
+  - Yue Cao
+  - Shenglong Ye
+  - Xizhou Zhu
+  - Lewei Lu
+  - Haodong Duan
+  - Yu Qiao
+  - Jifeng Dai
+  - Wenhai Wang
+  arxiv_categories:
+  - cs.CV
+  - cs.CL
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  - preference-alignment
+  - reasoning-self-improvement
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2502.14191
+  title: 'Multimodal RewardBench: Holistic Evaluation of Reward Models for Vision Language Models'
+  date: '2025-02-20'
+  updated: '2025-02-20'
+  url: https://arxiv.org/abs/2502.14191
+  abstract: 'Reward models play an essential role in training vision-language models (VLMs) by assessing output quality to
+    enable aligning with human preferences. Despite their importance, the research community lacks comprehensive open benchmarks
+    for evaluating multimodal reward models in VLMs. To address this gap, we introduce Multimodal RewardBench, an expert-annotated
+    benchmark covering six domains: general correctness, preference, knowledge, reasoning, safety, and visual question-answering.
+    Our dataset comprises 5,211 annotated (prompt, chosen response, rejected response) triplets collected from various VLMs.
+    In evaluating a range of VLM judges, we find that even the top-performing models, Gemini 1.5 Pro and Claude 3.5 Sonnet,
+    achieve only 72% overall accuracy. Notably, most models struggle in the reasoning and safety domains. These findings suggest
+    that Multimodal RewardBench offers a challenging testbed for advancing reward model development across multiple domains.
+    We release the benchmark at https://github.com/facebookresearch/multimodal_rewardbench.'
+  authors:
+  - Michihiro Yasunaga
+  - Luke Zettlemoyer
+  - Marjan Ghazvininejad
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - multimodal
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.13943
+  title: 'AdaptiveStep: Automatically Dividing Reasoning Step through Model Confidence'
+  date: '2025-02-19'
+  updated: '2025-05-31'
+  url: https://arxiv.org/abs/2502.13943
+  abstract: Current approaches for training Process Reward Models (PRMs) often involve breaking down responses into multiple
+    reasoning steps using rule-based techniques, such as using predefined placeholder tokens or setting the reasoning step's
+    length into a fixed size. These approaches overlook the fact that specific words do not typically mark true decision points
+    in a text. To address this, we propose AdaptiveStep, a method that divides reasoning steps based on the model's confidence
+    in predicting the next word. This division method provides more decision-making information at each step, enhancing downstream
+    tasks, such as reward model learning. Moreover, our method does not require manual annotation. We demonstrate its effectiveness
+    through experiments with AdaptiveStep-trained PRMs in mathematical reasoning and code generation tasks. Experimental results
+    indicate that the outcome PRM achieves state-of-the-art Best-of-N performance, surpassing greedy search strategy with
+    token-level value-guided decoding, while also reducing construction costs by over 30% compared to existing open-source
+    PRMs. In addition, we provide a thorough analysis and case study on the PRM's performance, transferability, and generalization
+    capabilities.
+  authors:
+  - Yuliang Liu
+  - Junjie Lu
+  - Zhaoling Chen
+  - Chaofeng Qu
+  - Jason Klein Liu
+  - Chonghan Liu
+  - Zefan Cai
+  - Yunhui Xia
+  - Li Zhao
+  - Jiang Bian
+  - Chuheng Zhang
+  - Wei Shen
+  - Zhouhan Lin
+  arxiv_categories:
+  - cs.AI
+  - cs.CL
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.11250
+  title: Uncertainty-Aware Step-wise Verification with Generative Reward Models
+  date: '2025-02-16'
+  updated: '2025-02-16'
+  url: https://arxiv.org/abs/2502.11250
+  abstract: Complex multi-step reasoning tasks, such as solving mathematical problems, remain challenging for large language
+    models (LLMs). While outcome supervision is commonly used, process supervision via process reward models (PRMs) provides
+    intermediate rewards to verify step-wise correctness in solution traces. However, as proxies for human judgement, PRMs
+    suffer from reliability issues, including susceptibility to reward hacking. In this work, we propose leveraging uncertainty
+    quantification (UQ) to enhance the reliability of step-wise verification with generative reward models for mathematical
+    reasoning tasks. We introduce CoT Entropy, a novel UQ method that outperforms existing approaches in quantifying a PRM's
+    uncertainty in step-wise verification. Our results demonstrate that incorporating uncertainty estimates improves the robustness
+    of judge-LM PRMs, leading to more reliable verification.
+  authors:
+  - Zihuiwen Ye
+  - Luckeciano Carvalho Melo
+  - Younesse Kaddar
+  - Phil Blunsom
+  - Sam Staton
+  - Yarin Gal
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.08922
+  title: Self-Consistency of the Internal Reward Models Improves Self-Rewarding Language Models
+  date: '2025-02-13'
+  updated: '2025-02-13'
+  url: https://arxiv.org/abs/2502.08922
+  abstract: Aligning Large Language Models (LLMs) with human preferences is crucial for their deployment in real-world applications.
+    Recent advancements in Self-Rewarding Language Models suggest that an LLM can use its internal reward models (such as
+    LLM-as-a-Judge) \cite{yuanself} to generate preference data, improving alignment performance without costly human annotation.
+    However, we find that different internal reward models within the same LLM often generate inconsistent preferences. This
+    inconsistency raises concerns about the reliability of self-generated preference data, hinders overall alignment performance,
+    and highlights the need for further research to ensure reliable and coherent alignment with human preferences. To address
+    this limitation, we propose Self-Consistent Internal Rewards (SCIR), a novel framework designed to enhance consistency
+    among internal reward models during training. In each training step, we collect preference predictions from multiple pre-defined
+    internal reward models and enforce consistency and confidence through an inconsistency penalty mechanism, thereby improving
+    the reliability of these internal reward models. We selectively use data with consistent predictions for preference optimization,
+    ensuring the quality of the preference data. By employing self-consistent internal rewards, our method significantly improves
+    the alignment performance and reward modeling capability of LLMs, outperforming baseline methods by a notable margin.
+  authors:
+  - Xin Zhou
+  - Yiwen Guo
+  - Ruotian Ma
+  - Tao Gui
+  - Qi Zhang
+  - Xuanjing Huang
+  arxiv_categories:
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.06703
+  title: Can 1B LLM Surpass 405B LLM? Rethinking Compute-Optimal Test-Time Scaling
+  date: '2025-02-10'
+  updated: '2025-02-10'
+  url: https://arxiv.org/abs/2502.06703
+  abstract: 'Test-Time Scaling (TTS) is an important method for improving the performance of Large Language Models (LLMs)
+    by using additional computation during the inference phase. However, current studies do not systematically analyze how
+    policy models, Process Reward Models (PRMs), and problem difficulty influence TTS. This lack of analysis limits the understanding
+    and practical use of TTS methods. In this paper, we focus on two core questions: (1) What is the optimal approach to scale
+    test-time computation across different policy models, PRMs, and problem difficulty levels? (2) To what extent can extended
+    computation improve the performance of LLMs on complex tasks, and can smaller language models outperform larger ones through
+    this approach? Through comprehensive experiments on MATH-500 and challenging AIME24 tasks, we have the following observations:
+    (1) The compute-optimal TTS strategy is highly dependent on the choice of policy model, PRM, and problem difficulty. (2)
+    With our compute-optimal TTS strategy, extremely small policy models can outperform larger models. For example, a 1B LLM
+    can exceed a 405B LLM on MATH-500. Moreover, on both MATH-500 and AIME24, a 0.5B LLM outperforms GPT-4o, a 3B LLM surpasses
+    a 405B LLM, and a 7B LLM beats o1 and DeepSeek-R1, while with higher inference efficiency. These findings show the significance
+    of adapting TTS strategies to the specific characteristics of each task and model and indicate that TTS is a promising
+    approach for enhancing the reasoning abilities of LLMs.'
+  authors:
+  - Runze Liu
+  - Junqi Gao
+  - Jian Zhao
+  - Kaiyan Zhang
+  - Xiu Li
+  - Biqing Qi
+  - Wanli Ouyang
+  - Bowen Zhou
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2501.07861
+  title: 'ReARTeR: Retrieval-Augmented Reasoning with Trustworthy Process Rewarding'
+  date: '2025-01-14'
+  updated: '2025-01-14'
+  url: https://arxiv.org/abs/2501.07861
+  abstract: 'Retrieval-Augmented Generation (RAG) systems for Large Language Models (LLMs) hold promise in knowledge-intensive
+    tasks but face limitations in complex multi-step reasoning. While recent methods have integrated RAG with chain-of-thought
+    reasoning or test-time search using Process Reward Models (PRMs), these approaches encounter challenges such as a lack
+    of explanations, bias in PRM training data, early-step bias in PRM scores, and insufficient post-training optimization
+    of reasoning potential. To address these issues, we propose Retrieval-Augmented Reasoning through Trustworthy Process
+    Rewarding (ReARTeR), a framework that enhances RAG systems'' reasoning capabilities through post-training and test-time
+    scaling. At test time, ReARTeR introduces Trustworthy Process Rewarding via a Process Reward Model for accurate scalar
+    scoring and a Process Explanation Model (PEM) for generating natural language explanations, enabling step refinement.
+    During post-training, it utilizes Monte Carlo Tree Search guided by Trustworthy Process Rewarding to collect high-quality
+    step-level preference data, optimized through Iterative Preference Optimization. ReARTeR addresses three core challenges:
+    (1) misalignment between PRM and PEM, tackled through off-policy preference learning; (2) bias in PRM training data, mitigated
+    by balanced annotation methods and stronger annotations for challenging examples; and (3) early-step bias in PRM, resolved
+    through a temporal-difference-based look-ahead search strategy. Experimental results on multi-step reasoning benchmarks
+    demonstrate significant improvements, underscoring ReARTeR''s potential to advance the reasoning capabilities of RAG systems.'
+  authors:
+  - Zhongxiang Sun
+  - Qipeng Wang
+  - Weijie Yu
+  - Xiaoxue Zang
+  - Kai Zheng
+  - Jun Xu
+  - Xiao Zhang
+  - Song Yang
+  - Han Li
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2501.07301
+  title: The Lessons of Developing Process Reward Models in Mathematical Reasoning
+  date: '2025-01-13'
+  updated: '2025-06-05'
+  url: https://arxiv.org/abs/2501.07301
+  abstract: 'Process Reward Models (PRMs) emerge as a promising approach for process supervision in mathematical reasoning
+    of Large Language Models (LLMs), which aim to identify and mitigate intermediate errors in the reasoning processes. However,
+    the development of effective PRMs faces significant challenges, particularly in data annotation and evaluation methodologies.
+    In this paper, through extensive experiments, we demonstrate that commonly used Monte Carlo (MC) estimation-based data
+    synthesis for PRMs typically yields inferior performance and generalization compared to LLM-as-a-judge and human annotation
+    methods. MC estimation relies on completion models to evaluate current-step correctness, leading to inaccurate step verification.
+    Furthermore, we identify potential biases in conventional Best-of-N (BoN) evaluation strategies for PRMs: (1) The unreliable
+    policy models generate responses with correct answers but flawed processes, leading to a misalignment between the evaluation
+    criteria of BoN and the PRM objectives of process verification. (2) The tolerance of PRMs of such responses leads to inflated
+    BoN scores. (3) Existing PRMs have a significant proportion of minimum scores concentrated on the final answer steps,
+    revealing the shift from process to outcome-based assessment in BoN Optimized PRMs. To address these challenges, we develop
+    a consensus filtering mechanism that effectively integrates MC estimation with LLM-as-a-judge and advocates a more comprehensive
+    evaluation framework that combines response-level and step-level metrics. Based on the mechanisms, we significantly improve
+    both model performance and data efficiency in the BoN evaluation and the step-wise error identification task. Finally,
+    we release a new state-of-the-art PRM that outperforms existing open-source'
+  authors:
+  - Zhenru Zhang
+  - Chujie Zheng
+  - Yangzhen Wu
+  - Beichen Zhang
+  - Runji Lin
+  - Bowen Yu
+  - Dayiheng Liu
+  - Jingren Zhou
+  - Junyang Lin
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2501.03124
+  title: 'PRMBench: A Fine-grained and Challenging Benchmark for Process-Level Reward Models'
+  date: '2025-01-06'
+  updated: '2025-06-28'
+  url: https://arxiv.org/abs/2501.03124
+  abstract: Process-level Reward Models (PRMs) are crucial for complex reasoning and decision-making tasks, where each intermediate
+    step plays an important role in the reasoning process. Since language models are prone to various types of errors during
+    the reasoning process, PRMs are required to possess nuanced capabilities for detecting various implicit error types in
+    real-world scenarios. However, current benchmarks primarily focus on step correctness, failing to evaluate PRMs' performance
+    systematically. To address this gap, we introduce PRMBench, a process-level benchmark specifically designed to assess
+    the fine-grained error detection capabilities of PRMs. PRMBench comprises 6,216 carefully designed problems and 83,456
+    step-level labels, evaluating models across multiple dimensions, including simplicity, soundness, and sensitivity. In
+    our experiments on 15 models, spanning both open-source PRMs and closed-source large language models prompted as critic
+    models, we uncover significant weaknesses in current PRMs. These findings underscore the challenges inherent in process-level
+    evaluation and highlight key directions for future research. We hope PRMBench can be a robust bench for advancing research
+    on PRM evaluation and development.
+  authors:
+  - Mingyang Song
+  - Zhaochen Su
+  - Xiaoye Qu
+  - Jiawei Zhou
+  - Yu Cheng
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2501.01290
+  title: 'ToolComp: A Multi-Tool Reasoning & Process Supervision Benchmark'
+  date: '2025-01-02'
+  updated: '2025-01-02'
+  url: https://arxiv.org/abs/2501.01290
+  abstract: Despite recent advances in AI, the development of systems capable of executing complex, multi-step reasoning tasks
+    involving multiple tools remains a significant challenge. Current benchmarks fall short in capturing the real-world complexity
+    of tool-use reasoning, where verifying the correctness of not only the final answer but also the intermediate steps is
+    important for evaluation, development, and identifying failures during inference time. To bridge this gap, we introduce
+    ToolComp, a comprehensive benchmark designed to evaluate multi-step tool-use reasoning. ToolComp is developed through
+    a collaboration between models and human annotators, featuring human-edited/verified prompts, final answers, and process
+    supervision labels, allowing for the evaluation of both final outcomes and intermediate reasoning. Evaluation across six
+    different model families demonstrates the challenging nature of our dataset, with the majority of models achieving less
+    than 50% accuracy. Additionally, we generate synthetic training data to compare the performance of outcome-supervised
+    reward models (ORMs) with process-supervised reward models (PRMs) to assess their ability to improve complex tool-use
+    reasoning as evaluated by ToolComp. Our results show that PRMs generalize significantly better than ORMs, achieving a
+    19% and 11% improvement in rank@1 accuracy for ranking base and fine-tuned model trajectories, respectively. These findings
+    highlight the critical role of process supervision in both the evaluation and training of AI models, paving the way for
+    more robust and capable systems in complex, multi-step tool-use tasks.
+  authors:
+  - Vaskar Nath
+  - Pranav Raja
+  - Claire Yoon
+  - Sean Hendryx
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  - reward-verifiers
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2605.22939
+  title: Learnability-Informed Fine-Tuning of Diffusion Language Models
+  date: '2026-05-21'
+  updated: '2026-05-21'
+  url: https://arxiv.org/abs/2605.22939
+  abstract: We aim to improve the reasoning capabilities of diffusion language models (DLMs). While SFT is a popular post-training
+    recipe for autoregressive models, its use in DLMs faces challenges and can even hurt performance, though the underlying
+    causes remain understudied. Our analysis reveals that vanilla SFT overlooks learnability, namely what and when tokens
+    are learned. Specifically, rare tokens are difficult to learn when most of the input is masked, whereas it is straightforward
+    and thus of little value to learn common tokens when most of the input is unmasked. Motivated by our analysis, we propose
+    LIFT, an efficient SFT-based post-training algorithm for DLMs. LIFT learns easy tokens when most of the input is masked
+    and hard tokens when more context is available, thus aligning the training with the information available at different
+    diffusion time steps. Our results show that LIFT outperforms existing SFT baselines across six reasoning benchmarks, achieving
+    up to a 3x relative gain on AIME'24 and AIME'25. Our code is publicly available at https://github.com/divelab/LIFT.
+  authors:
+  - Shubham Parashar
+  - Atharv Chagi
+  - Jacob Helwig
+  - Lakshmi Jotsna
+  - Sushil Vemuri
+  - James Caverlee
+  - Dileep Kalathil
+  - Shuiwang Ji
+  arxiv_categories:
+  - cs.CL
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2604.04857
+  title: 'The Blind Spot of Adaptation: Quantifying and Mitigating Forgetting in Fine-tuned Driving Models'
+  date: '2026-04-06'
+  updated: '2026-04-06'
+  url: https://arxiv.org/abs/2604.04857
+  abstract: The integration of Vision-Language Models (VLMs) into autonomous driving promises to solve long-tail scenarios,
+    but this paradigm faces the critical and unaddressed challenge of catastrophic forgetting. The very fine-tuning process
+    used to adapt these models to driving-specific data simultaneously erodes their invaluable pre-trained world knowledge,
+    creating a self-defeating paradox that undermines the core reason for their use. This paper provides the first systematic
+    investigation into this phenomenon. We introduce a new large-scale dataset of 180K scenes, which enables the first-ever
+    benchmark specifically designed to quantify catastrophic forgetting in autonomous driving. Our analysis reveals that existing
+    methods suffer from significant knowledge degradation. To address this, we propose the Drive Expert Adapter (DEA), a novel
+    framework that circumvents this trade-off by shifting adaptation from the weight space to the prompt space. DEA dynamically
+    routes inference through different knowledge experts based on scene-specific cues, enhancing driving-task performance
+    without corrupting the model's foundational parameters. Extensive experiments demonstrate that our approach not only achieves
+    state-of-the-art results on driving tasks but also effectively mitigates catastrophic forgetting, preserving the essential
+    generalization capabilities that make VLMs a transformative force for autonomous systems. Data and model are released
+    at FidelityDrivingBench.
+  authors:
+  - Runhao Mao
+  - Hanshi Wang
+  - Yixiang Yang
+  - Qianli Ma
+  - Jingmeng Zhou
+  - Zhipeng Zhang
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.18178
+  title: 'VLM-AutoDrive: Post-Training Vision-Language Models for Safety-Critical Autonomous Driving Events'
+  date: '2026-03-18'
+  updated: '2026-05-15'
+  url: https://arxiv.org/abs/2603.18178
+  abstract: The rapid growth of ego-centric dashcam footage presents a major challenge for detecting safety-critical events
+    such as collisions and near-collisions, scenarios that are brief, rare, and difficult for generic vision models to capture.
+    While multimodal large language models (MLLMs) demonstrate strong general reasoning ability, they underperform in driving
+    contexts due to domain and temporal misalignment. We introduce VLM-AutoDrive, a modular post-training framework for adapting
+    pretrained Vision-Language Models (VLMs) to high-fidelity anomaly detection. The framework integrates metadata-derived
+    captions, LLM-generated descriptions, visual question answering (VQA) pairs, and chain-of-thought (CoT) reasoning supervision
+    to enable domain-aligned and interpretable learning. Off-the-shelf VLMs such as NVIDIA's Cosmos-Reason1 7B (CR1) exhibit
+    near-zero Collision recall in zero-shot settings; fine-tuning with VLM-AutoDrive improves Collision F1 from 0.00 to 0.69
+    and overall accuracy from 35.35% to 77.27%. VLM-AutoDrive offers a scalable recipe for adapting general-purpose VLMs to
+    safety-critical, temporally localized perception tasks. Evaluated on real-world Nexar dashcam videos, it achieves substantial
+    gains in Collision and Near-Collision detection while producing interpretable reasoning traces, bridging the gap between
+    perception, causality, and decision reasoning in autonomous driving.
+  authors:
+  - Mohammad Qazim Bhat
+  - Yufan Huang
+  - Niket Agarwal
+  - Hao Wang
+  - Michael Woods
+  - John Kenyon
+  - Tsung-Yi Lin
+  - Xiaodong Yang
+  - Ming-Yu Liu
+  - Kevin Xie
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.12478
+  title: 'Less Data, Faster Convergence: Goal-Driven Data Optimization for Multimodal Instruction Tuning'
+  date: '2026-03-12'
+  updated: '2026-08-17'
+  url: https://arxiv.org/abs/2603.12478
+  abstract: Multimodal instruction tuning is often compute-inefficient because training budgets are spread across large mixed
+    image-video pools whose utility is highly uneven. We present Goal-Driven Data Optimization (GDO), a framework that computes
+    six sample descriptors for each candidate and constructs optimized 1$\times$ training subsets for different goals. Under
+    a fixed one-epoch Qwen3-VL-8B-Instruct training and evaluation recipe on 8 H20 GPUs, GDO uses far fewer training samples
+    than the Uni-10x baseline while converging faster and achieving higher accuracy. Relative to the fixed 512k-sample Uni-10x
+    baseline, GDO reaches the Uni-10x reference after 35.4k samples on MVBench, 26.6k on VideoMME, 27.3k on MLVU, and 34.7k
+    on LVBench, while improving Accuracy by +1.38, +1.67, +3.08, and +0.84 percentage points, respectively. The gains are
+    largest on MVBench and MLVU, while LVBench improves more modestly, consistent with its ultra-long-video setting and the
+    mismatch between that benchmark and the short-video/image-dominant training pool. Across MinLoss, Diverse, Temp, and Temp+,
+    stronger temporal emphasis yields steadily better long-video understanding behavior. Overall, GDO provides a goal-driven
+    data optimization framework that enables faster convergence with fewer training samples under a fixed training protocol.
+    Code is available at https://github.com/rujiewu/GDO.
+  authors:
+  - Rujie Wu
+  - Haozhe Zhao
+  - Hai Ci
+  - Yizhou Wang
+  arxiv_categories:
+  - cs.CV
+  - cs.LG
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2603.01928
+  title: 'LaST-VLA: Thinking in Latent Spatio-Temporal Space for Vision-Language-Action in Autonomous Driving'
+  date: '2026-03-02'
+  updated: '2026-03-12'
+  url: https://arxiv.org/abs/2603.01928
+  abstract: While Vision-Language-Action (VLA) models have revolutionized autonomous driving by unifying perception and planning,
+    their reliance on explicit textual Chain-of-Thought (CoT) leads to semantic-perceptual decoupling and perceptual-symbolic
+    conflicts. Recent shifts toward latent reasoning attempt to bypass these bottlenecks by thinking in continuous hidden
+    space. However, without explicit intermediate constraints, standard latent CoT often operates as a physics-agnostic representation.
+    To address this, we propose the Latent Spatio-Temporal VLA (LaST-VLA), a framework shifting the reasoning paradigm from
+    discrete symbolic processing into a physically grounded Latent Spatio-Temporal CoT. By implementing a dual-feature alignment
+    mechanism, we distill geometric constraints from 3D foundation models and dynamic foresight from world models directly
+    into the latent space. Coupled with a progressive SFT training strategy that transitions from feature alignment to trajectory
+    generation, and refined via Reinforcement Learning with Group Relative Policy Optimization (GRPO) to ensure safety and
+    rule compliance. \method~setting a new record on NAVSIM v1 (91.3 PDMS) and NAVSIM v2 (87.1 EPDMS), while excelling in
+    spatial-temporal reasoning on SURDS and NuDynamics benchmarks.
+  authors:
+  - Yuechen Luo
+  - Fang Li
+  - Shaoqing Xu
+  - Yang Ji
+  - Zehan Zhang
+  - Bing Wang
+  - Yuannan Shen
+  - Jianwei Cui
+  - Long Chen
+  - Guang Chen
+  - Hangjun Ye
+  - Zhi-Xin Yang
+  - Fuxi Wen
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2601.12901
+  title: 'PlannerRFT: Reinforcing Diffusion Planners through Closed-Loop and Sample-Efficient Fine-Tuning'
+  date: '2026-01-19'
+  updated: '2026-01-19'
+  url: https://arxiv.org/abs/2601.12901
+  abstract: Diffusion-based planners have emerged as a promising approach for human-like trajectory generation in autonomous
+    driving. Recent works incorporate reinforcement fine-tuning to enhance the robustness of diffusion planners through reward-oriented
+    optimization in a generation-evaluation loop. However, they struggle to generate multi-modal, scenario-adaptive trajectories,
+    hindering the exploitation efficiency of informative rewards during fine-tuning. To resolve this, we propose PlannerRFT,
+    a sample-efficient reinforcement fine-tuning framework for diffusion-based planners. PlannerRFT adopts a dual-branch optimization
+    that simultaneously refines the trajectory distribution and adaptively guides the denoising process toward more promising
+    exploration, without altering the original inference pipeline. To support parallel learning at scale, we develop nuMax,
+    an optimized simulator that achieves 10 times faster rollout compared to native nuPlan. Extensive experiments shows that
+    PlannerRFT yields state-of-the-art performance with distinct behaviors emerging during the learning process.
+  authors:
+  - Hongchen Li
+  - Tianyu Li
+  - Jiazhi Yang
+  - Haochen Tian
+  - Caojun Wang
+  - Lei Shi
+  - Mingyang Shang
+  - Zengrong Lin
+  - Gaoqiang Wu
+  - Zhihui Hao
+  - Xianpeng Lang
+  - Jia Hu
+  - Hongyang Li
+  arxiv_categories:
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - generative-media
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2601.03198
+  title: Empowering Reliable Visual-Centric Instruction Following in MLLMs
+  date: '2026-01-06'
+  updated: '2026-01-06'
+  url: https://arxiv.org/abs/2601.03198
+  abstract: Evaluating the instruction-following (IF) capabilities of Multimodal Large Language Models (MLLMs) is essential
+    for rigorously assessing how faithfully model outputs adhere to user-specified intentions. Nevertheless, existing benchmarks
+    for evaluating MLLMs' instruction-following capability primarily focus on verbal instructions in the textual modality.
+    These limitations hinder a thorough analysis of instruction-following capabilities, as they overlook the implicit constraints
+    embedded in the semantically rich visual modality. To address this gap, we introduce VC-IFEval, a new benchmark accompanied
+    by a systematically constructed dataset that evaluates MLLMs' instruction-following ability under multimodal settings.
+    Our benchmark systematically incorporates vision-dependent constraints into instruction design, enabling a more rigorous
+    and fine-grained assessment of how well MLLMs align their outputs with both visual input and textual instructions. Furthermore,
+    by fine-tuning MLLMs on our dataset, we achieve substantial gains in visual instruction-following accuracy and adherence.
+    Through extensive evaluation across representative MLLMs, we provide new insights into the strengths and limitations of
+    current models.
+  authors:
+  - Weilei He
+  - Feng Ju
+  - Zhiyuan Fan
+  - Rui Min
+  - Minhao Cheng
+  - Yi R. Fung
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2503.06072
+  title: A Survey on Post-training of Large Language Models
+  date: '2025-03-08'
+  updated: '2025-08-01'
+  url: https://arxiv.org/abs/2503.06072
+  abstract: 'The emergence of Large Language Models (LLMs) has fundamentally transformed natural language processing, making
+    them indispensable across domains ranging from conversational systems to scientific exploration. However, their pre-trained
+    architectures often reveal limitations in specialized contexts, including restricted reasoning capacities, ethical uncertainties,
+    and suboptimal domain-specific performance. These challenges necessitate advanced post-training language models (PoLMs)
+    to address these shortcomings, such as OpenAI-o1/o3 and DeepSeek-R1 (collectively known as Large Reasoning Models, or
+    LRMs). This paper presents the first comprehensive survey of PoLMs, systematically tracing their evolution across five
+    core paradigms: Fine-tuning, which enhances task-specific accuracy; Alignment, which ensures ethical coherence and alignment
+    with human preferences; Reasoning, which advances multi-step inference despite challenges in reward design; Efficiency,
+    which optimizes resource utilization amidst increasing complexity; Integration and Adaptation, which extend capabilities
+    across diverse modalities while addressing coherence issues. Charting progress from ChatGPT''s alignment strategies to
+    DeepSeek-R1''s innovative reasoning advancements, we illustrate how PoLMs leverage datasets to mitigate biases, deepen
+    reasoning capabilities, and enhance domain adaptability. Our contributions include a pioneering synthesis of PoLM evolution,
+    a structured taxonomy categorizing techniques and datasets, and a strategic agenda emphasizing the role of LRMs in improving
+    reasoning proficiency and domain flexibility. As the first survey of its scope, this work consolidates recent PoLM advancements
+    and establishes a rigorous intellectual framework for future research, fostering the development'
+  authors:
+  - Guiyao Tie
+  - Zeli Zhao
+  - Dingjie Song
+  - Fuyang Wei
+  - Rong Zhou
+  - Yurou Dai
+  - Wen Yin
+  - Zhejian Yang
+  - Jiangyue Yan
+  - Yao Su
+  - Zhenhan Dai
+  - Yifeng Xie
+  - Yihan Cao
+  - Lichao Sun
+  - Pan Zhou
+  - Lifang He
+  - Hechang Chen
+  - Yu Zhang
+  - Qingsong Wen
+  - Tianming Liu
+  - Neil Zhenqiang Gong
+  - Jiliang Tang
+  - Caiming Xiong
+  - Heng Ji
+  - Philip S. Yu
+  - Jianfeng Gao
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.21321
+  title: 'LLM Post-Training: A Deep Dive into Reasoning Large Language Models'
+  date: '2025-02-28'
+  updated: '2025-03-24'
+  url: https://arxiv.org/abs/2502.21321
+  abstract: 'Large Language Models (LLMs) have transformed the natural language processing landscape and brought to life diverse
+    applications. Pretraining on vast web-scale data has laid the foundation for these models, yet the research community
+    is now increasingly shifting focus toward post-training techniques to achieve further breakthroughs. While pretraining
+    provides a broad linguistic foundation, post-training methods enable LLMs to refine their knowledge, improve reasoning,
+    enhance factual accuracy, and align more effectively with user intents and ethical considerations. Fine-tuning, reinforcement
+    learning, and test-time scaling have emerged as critical strategies for optimizing LLMs performance, ensuring robustness,
+    and improving adaptability across various real-world tasks. This survey provides a systematic exploration of post-training
+    methodologies, analyzing their role in refining LLMs beyond pretraining, addressing key challenges such as catastrophic
+    forgetting, reward hacking, and inference-time trade-offs. We highlight emerging directions in model alignment, scalable
+    adaptation, and inference-time reasoning, and outline future research directions. We also provide a public repository
+    to continually track developments in this fast-evolving field: https://github.com/mbzuai-oryx/Awesome-LLM-Post-training.'
+  authors:
+  - Komal Kumar
+  - Tajamul Ashraf
+  - Omkar Thawakar
+  - Rao Muhammad Anwer
+  - Hisham Cholakkal
+  - Mubarak Shah
+  - Ming-Hsuan Yang
+  - Phillip H. S. Torr
+  - Fahad Shahbaz Khan
+  - Salman Khan
+  arxiv_categories:
+  - cs.CL
+  - cs.CV
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.19230
+  title: 'Two Heads Are Better Than One: Dual-Model Verbal Reflection at Inference-Time'
+  date: '2025-02-26'
+  updated: '2025-09-28'
+  url: https://arxiv.org/abs/2502.19230
+  abstract: Although preference optimization methods have improved reasoning performance in Large Language Models (LLMs),
+    they often lack transparency regarding why one reasoning outcome is preferred over another. This limitation is especially
+    critical in Automated Student Answer Scoring (ASAS), where explainability is essential to justify assessment outcomes.
+    Verbal reinforcement learning offers the potential to generate explicit reflection, but it tends to produce superficial
+    critiques that can harm assessment performance. Existing LLMs also struggle to reliably detect subtle reasoning errors
+    in ASAS tasks. Moreover, manually identifying intermediate reasoning errors is expensive and difficult to scale. To address
+    these challenges, we introduce a contrastive reflection synthesis pipeline that generates precise verbal feedback by identifying
+    discrepancies in structure reasoning graph paths. Leveraging these synthetic reflection data, we propose DARS, a Dual-model
+    Reflective Scoring framework featuring a dedicated Critic model trained for effective reflection. DARS achieves strong
+    performance and consistently outperforms existing ASAS baselines across all evaluation metrics. Extensive experiments
+    further provide novel insights into the value of reflection data, framework design, and the scaling behavior of DARS.
+    We release the DARS code at https://github.com/lijiazheng99/DARS.
+  authors:
+  - Jiazheng Li
+  - Yuxiang Zhou
+  - Junru Lu
+  - Gladys Tyen
+  - Lin Gui
+  - Cesare Aloisi
+  - Yulan He
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.19187
+  title: BIG-Bench Extra Hard
+  date: '2025-02-26'
+  updated: '2025-05-06'
+  url: https://arxiv.org/abs/2502.19187
+  abstract: 'Large language models (LLMs) are increasingly deployed in everyday applications, demanding robust general reasoning
+    capabilities and diverse reasoning skillset. However, current LLM reasoning benchmarks predominantly focus on mathematical
+    and coding abilities, leaving a gap in evaluating broader reasoning proficiencies. One particular exception is the BIG-Bench
+    dataset, which has served as a crucial benchmark for evaluating the general reasoning capabilities of LLMs, thanks to
+    its diverse set of challenging tasks that allowed for a comprehensive assessment of general reasoning across various skills
+    within a unified framework. However, recent advances in LLMs have led to saturation on BIG-Bench, and its harder version
+    BIG-Bench Hard (BBH). State-of-the-art models achieve near-perfect scores on many tasks in BBH, thus diminishing its utility.
+    To address this limitation, we introduce BIG-Bench Extra Hard (BBEH), a new benchmark designed to push the boundaries
+    of LLM reasoning evaluation. BBEH replaces each task in BBH with a novel task that probes a similar reasoning capability
+    but exhibits significantly increased difficulty. We evaluate various models on BBEH and observe a (harmonic) average accuracy
+    of 9.8\% for the best general-purpose model and 44.8\% for the best reasoning-specialized model, indicating substantial
+    room for improvement and highlighting the ongoing challenge of achieving robust general reasoning in LLMs. We release
+    BBEH publicly at: https://github.com/google-deepmind/bbeh.'
+  authors:
+  - Mehran Kazemi
+  - Bahare Fatemi
+  - Hritik Bansal
+  - John Palowitch
+  - Chrysovalantis Anastasiou
+  - Sanket Vaibhav Mehta
+  - Lalit K. Jain
+  - Virginia Aglietti
+  - Disha Jindal
+  - Peter Chen
+  - Nishanth Dikkala
+  - Gladys Tyen
+  - Xin Liu
+  - Uri Shalit
+  - Silvia Chiappa
+  - Kate Olszewska
+  - Yi Tay
+  - Vinh Q. Tran
+  - Quoc V. Le
+  - Orhan Firat
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.17925
+  title: 'LeanProgress: Guiding Search for Neural Theorem Proving via Proof Progress Prediction'
+  date: '2025-02-25'
+  updated: '2026-01-18'
+  url: https://arxiv.org/abs/2502.17925
+  abstract: 'Mathematical reasoning remains a significant challenge for Large Language Models (LLMs) due to hallucinations.
+    When combined with formal proof assistants like Lean, these hallucinations can be eliminated through rigorous verification,
+    making theorem proving reliable. However, even with formal verification, LLMs still struggle with long proofs and complex
+    mathematical formalizations. While Lean with LLMs offers valuable assistance with retrieving lemmas, generating tactics,
+    or even complete proofs, it lacks a crucial capability: providing a sense of proof progress. This limitation particularly
+    impacts the overall development efficiency in large formalization projects. We introduce LeanProgress, a method that predicts
+    the progress in the proof. Training and evaluating our models made on a large corpus of Lean proofs from Lean Workbook
+    Plus and Mathlib4 and how many steps remain to complete it, we employ data preprocessing and balancing techniques to handle
+    the skewed distribution of proof lengths. Our experiments show that LeanProgress achieves an overall prediction accuracy
+    of 75.8% in predicting the amount of progress and, hence, the remaining number of steps. When integrated into a best-first
+    search framework using Reprover, our method shows a 3.8% improvement on Mathlib4 compared to baseline performances of
+    41.4%, particularly for longer proofs. These results demonstrate how proof progress prediction can enhance both automated
+    and interactive theorem proving, enabling users to make more informed decisions about proof strategies. Our code is merged
+    in this library here https://github.com/lean-dojo/LeanDojo-v2.'
+  authors:
+  - Robert Joseph George
+  - Suozhi Huang
+  - Peiyang Song
+  - Anima Anandkumar
+  arxiv_categories:
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.14739
+  title: 'SuperGPQA: Scaling LLM Evaluation across 285 Graduate Disciplines'
+  date: '2025-02-20'
+  updated: '2025-03-28'
+  url: https://arxiv.org/abs/2502.14739
+  abstract: Large language models (LLMs) have demonstrated remarkable proficiency in mainstream academic disciplines such
+    as mathematics, physics, and computer science. However, human knowledge encompasses over 200 specialized disciplines,
+    far exceeding the scope of existing benchmarks. The capabilities of LLMs in many of these specialized fields-particularly
+    in light industry, agriculture, and service-oriented disciplines-remain inadequately evaluated. To address this gap, we
+    present SuperGPQA, a comprehensive benchmark that evaluates graduate-level knowledge and reasoning capabilities across
+    285 disciplines. Our benchmark employs a novel Human-LLM collaborative filtering mechanism to eliminate trivial or ambiguous
+    questions through iterative refinement based on both LLM responses and expert feedback. Our experimental results reveal
+    significant room for improvement in the performance of current state-of-the-art LLMs across diverse knowledge domains
+    (e.g., the reasoning-focused model DeepSeek-R1 achieved the highest accuracy of 61.82% on SuperGPQA), highlighting the
+    considerable gap between current model capabilities and artificial general intelligence. Additionally, we present comprehensive
+    insights from our management of a large-scale annotation process, involving over 80 expert annotators and an interactive
+    Human-LLM collaborative system, offering valuable methodological guidance for future research initiatives of comparable
+    scope.
+  authors:
+  - M-A-P Team
+  - Xinrun Du
+  - Yifan Yao
+  - Kaijing Ma
+  - Bingli Wang
+  - Tianyu Zheng
+  - King Zhu
+  - Minghao Liu
+  - Yiming Liang
+  - Xiaolong Jin
+  - Zhenlin Wei
+  - Chujie Zheng
+  - Kaixin Deng
+  - Shawn Gavin
+  - Shian Jia
+  - Sichao Jiang
+  - Yiyan Liao
+  - Rui Li
+  - Qinrui Li
+  - Sirun Li
+  - Yizhi Li
+  - Yunwen Li
+  - David Ma
+  - Yuansheng Ni
+  - Haoran Que
+  - Qiyao Wang
+  - Zhoufutu Wen
+  - Siwei Wu
+  - Tyshawn Hsing
+  - Ming Xu
+  - Zhenzhu Yang
+  - Zekun Moore Wang
+  - Junting Zhou
+  - Yuelin Bai
+  - Xingyuan Bu
+  - Chenglin Cai
+  - Liang Chen
+  - Yifan Chen
+  - Chengtuo Cheng
+  - Tianhao Cheng
+  - Keyi Ding
+  - Siming Huang
+  - Yun Huang
+  - Yaoru Li
+  - Yizhe Li
+  - Zhaoqun Li
+  - Tianhao Liang
+  - Chengdong Lin
+  - Hongquan Lin
+  - Yinghao Ma
+  - Tianyang Pang
+  - Zhongyuan Peng
+  - Zifan Peng
+  - Qige Qi
+  - Shi Qiu
+  - Xingwei Qu
+  - Shanghaoran Quan
+  - Yizhou Tan
+  - Zili Wang
+  - Chenqing Wang
+  - Hao Wang
+  - Yiya Wang
+  - Yubo Wang
+  - Jiajun Xu
+  - Kexin Yang
+  - Ruibin Yuan
+  - Yuanhao Yue
+  - Tianyang Zhan
+  - Chun Zhang
+  - Jinyang Zhang
+  - Xiyue Zhang
+  - Xingjian Zhang
+  - Yue Zhang
+  - Yongchi Zhao
+  - Xiangyu Zheng
+  - Chenghua Zhong
+  - Yang Gao
+  - Zhoujun Li
+  - Dayiheng Liu
+  - Qian Liu
+  - Tianyu Liu
+  - Shiwen Ni
+  - Junran Peng
+  - Yujia Qin
+  - Wenbo Su
+  - Guoyin Wang
+  - Shi Wang
+  - Jian Yang
+  - Min Yang
+  - Meng Cao
+  - Xiang Yue
+  - Zhaoxiang Zhang
+  - Wangchunshu Zhou
+  - Jiaheng Liu
+  - Qunshu Lin
+  - Wenhao Huang
+  - Ge Zhang
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.11886
+  title: 'LIMR: Less is More for RL Scaling'
+  date: '2025-02-17'
+  updated: '2025-02-17'
+  url: https://arxiv.org/abs/2502.11886
+  abstract: 'In this paper, we ask: what truly determines the effectiveness of RL training data for enhancing language models''
+    reasoning capabilities? While recent advances like o1, Deepseek R1, and Kimi1.5 demonstrate RL''s potential, the lack
+    of transparency about training data requirements has hindered systematic progress. Starting directly from base models
+    without distillation, we challenge the assumption that scaling up RL training data inherently improves performance. we
+    demonstrate that a strategically selected subset of just 1,389 samples can outperform the full 8,523-sample dataset. We
+    introduce Learning Impact Measurement (LIM), an automated method to evaluate and prioritize training samples based on
+    their alignment with model learning trajectories, enabling efficient resource utilization and scalable implementation.
+    Our method achieves comparable or even superior performance using only 1,389 samples versus the full 8,523 samples dataset.
+    Notably, while recent data-efficient approaches (e.g., LIMO and s1) show promise with 32B-scale models, we find it significantly
+    underperforms at 7B-scale through supervised fine-tuning (SFT). In contrast, our RL-based LIMR achieves 16.7% higher accuracy
+    on AIME24 and outperforms LIMO and s1 by 13.0% and 22.2% on MATH500. These results fundamentally reshape our understanding
+    of RL scaling in LLMs, demonstrating that precise sample selection, rather than data scale, may be the key to unlocking
+    enhanced reasoning capabilities. For reproducible research and future innovation, we are open-sourcing LIMR, including
+    implementation of LIM, training and evaluation code, curated datasets, and trained models at https://github.com/GAIR-NLP/LIMR.'
+  authors:
+  - Xuefeng Li
+  - Haoyang Zou
+  - Pengfei Liu
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2502.04327
+  title: Value-Based Deep RL Scales Predictably
+  date: '2025-02-06'
+  updated: '2025-07-25'
+  url: https://arxiv.org/abs/2502.04327
+  abstract: 'Scaling data and compute is critical to the success of modern ML. However, scaling demands predictability: we
+    want methods to not only perform well with more compute or data, but also have their performance be predictable from small-scale
+    runs, without running the large-scale experiment. In this paper, we show that value-based off-policy RL methods are predictable
+    despite community lore regarding their pathological behavior. First, we show that data and compute requirements to attain
+    a given performance level lie on a Pareto frontier, controlled by the updates-to-data (UTD) ratio. By estimating this
+    frontier, we can predict this data requirement when given more compute, and this compute requirement when given more data.
+    Second, we determine the optimal allocation of a total resource budget across data and compute for a given performance
+    and use it to determine hyperparameters that maximize performance for a given budget. Third, this scaling is enabled by
+    first estimating predictable relationships between hyperparameters, which is used to manage effects of overfitting and
+    plasticity loss unique to RL. We validate our approach using three algorithms: SAC, BRO, and PQL on DeepMind Control,
+    OpenAI gym, and IsaacGym, when extrapolating to higher levels of data, compute, budget, or performance.'
+  authors:
+  - Oleh Rybkin
+  - Michal Nauman
+  - Preston Fu
+  - Charlie Snell
+  - Pieter Abbeel
+  - Sergey Levine
+  - Aviral Kumar
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2501.14249
+  title: Humanity's Last Exam
+  date: '2025-01-24'
+  updated: '2026-07-28'
+  url: https://arxiv.org/abs/2501.14249
+  abstract: 'Benchmarks are important tools for tracking the rapid advancements in large language model (LLM) capabilities.
+    However, benchmarks are not keeping pace in difficulty: LLMs now achieve over 90\% accuracy on popular benchmarks like
+    MMLU, limiting informed measurement of state-of-the-art LLM capabilities. In response, we introduce Humanity''s Last Exam
+    (HLE), a multi-modal benchmark at the frontier of human knowledge, designed to be the final closed-ended academic benchmark
+    of its kind with broad subject coverage. HLE consists of 2,500 questions across dozens of subjects, including mathematics,
+    humanities, and the natural sciences. HLE is developed globally by subject-matter experts and consists of multiple-choice
+    and short-answer questions suitable for automated grading. Each question has a known solution that is unambiguous and
+    easily verifiable, but cannot be quickly answered via internet retrieval. State-of-the-art LLMs demonstrate low accuracy
+    and calibration on HLE, highlighting a significant gap between current LLM capabilities and the expert human frontier
+    on closed-ended academic questions. To inform research and policymaking upon a clear understanding of model capabilities,
+    we publicly release HLE at https://lastexam.ai.'
+  authors:
+  - Long Phan
+  - Alice Gatti
+  - Ziwen Han
+  - Nathaniel Li
+  - Josephina Hu
+  - Hugh Zhang
+  - Chen Bo Calvin Zhang
+  - Mohamed Shaaban
+  - John Ling
+  - Sean Shi
+  - Michael Choi
+  - Anish Agrawal
+  - Arnav Chopra
+  - Adam Khoja
+  - Ryan Kim
+  - Richard Ren
+  - Jason Hausenloy
+  - Oliver Zhang
+  - Mantas Mazeika
+  - Dmitry Dodonov
+  - Tung Nguyen
+  - Jaeho Lee
+  - Daron Anderson
+  - Mikhail Doroshenko
+  - Alun Cennyth Stokes
+  - Mobeen Mahmood
+  - Oleksandr Pokutnyi
+  - Oleg Iskra
+  - Jessica P. Wang
+  - John-Clark Levin
+  - Mstyslav Kazakov
+  - Fiona Feng
+  - Steven Y. Feng
+  - Haoran Zhao
+  - Michael Yu
+  - Varun Gangal
+  - Chelsea Zou
+  - Zihan Wang
+  - Serguei Popov
+  - Robert Gerbicz
+  - Geoff Galgon
+  - Johannes Schmitt
+  - Will Yeadon
+  - Yongki Lee
+  - Scott Sauers
+  - Alvaro Sanchez
+  - Fabian Giska
+  - Marc Roth
+  - Søren Riis
+  - Saiteja Utpala
+  - Noah Burns
+  - Gashaw M. Goshu
+  - Mohinder Maheshbhai Naiya
+  - Chidozie Agu
+  - Zachary Giboney
+  - Antrell Cheatom
+  - Francesco Fournier-Facio
+  - Sarah-Jane Crowson
+  - Lennart Finke
+  - Zerui Cheng
+  - Jennifer Zampese
+  - Ryan G. Hoerr
+  - Mark Nandor
+  - Hyunwoo Park
+  - Tim Gehrunger
+  - Jiaqi Cai
+  - Ben McCarty
+  - Alexis C Garretson
+  - Edwin Taylor
+  - Damien Sileo
+  - Qiuyu Ren
+  - Usman Qazi
+  - Lianghui Li
+  - Jungbae Nam
+  - John B. Wydallis
+  - Pavel Arkhipov
+  - Jack Wei Lun Shi
+  - Aras Bacho
+  - Chris G. Willcocks
+  - Hangrui Cao
+  - Sumeet Motwani
+  - Emily de Oliveira Santos
+  - Johannes Veith
+  - Edward Vendrow
+  - Doru Cojoc
+  - Kengo Zenitani
+  - Joshua Robinson
+  - Longke Tang
+  - Yuqi Li
+  - Joshua Vendrow
+  - Natanael Wildner Fraga
+  - Vladyslav Kuchkin
+  - Andrey Pupasov Maksimov
+  - Pierre Marion
+  - Denis Efremov
+  - Jayson Lynch
+  - Kaiqu Liang
+  - Aleksandar Mikov
+  - Andrew Gritsevskiy
+  - Julien Guillod
+  - Gözdenur Demir
+  - Dakotah Martinez
+  - Ben Pageler
+  - Kevin Zhou
+  - Saeed Soori
+  - Ori Press
+  - Henry Tang
+  - Paolo Rissone
+  - Sean R. Green
+  - Lina Brüssel
+  - Moon Twayana
+  - Aymeric Dieuleveut
+  - Joseph Marvin Imperial
+  - Ameya Prabhu
+  - Jinzhou Yang
+  - Nick Crispino
+  - Arun Rao
+  - Dimitri Zvonkine
+  - Gabriel Loiseau
+  - Mikhail Kalinin
+  - Marco Lukas
+  - Ciprian Manolescu
+  - Nate Stambaugh
+  - Subrata Mishra
+  - Tad Hogg
+  - Carlo Bosio
+  - Brian P Coppola
+  - Julian Salazar
+  - Jaehyeok Jin
+  - Rafael Sayous
+  - Stefan Ivanov
+  - Philippe Schwaller
+  - Shaipranesh Senthilkuma
+  - Andres M Bran
+  - Andres Algaba
+  - Kelsey Van den Houte
+  - Lynn Van Der Sypt
+  - Brecht Verbeken
+  - David Noever
+  - Alexei Kopylov
+  - Benjamin Myklebust
+  - Bikun Li
+  - Lisa Schut
+  - Evgenii Zheltonozhskii
+  - Qiaochu Yuan
+  - Derek Lim
+  - Richard Stanley
+  - Tong Yang
+  - John Maar
+  - Julian Wykowski
+  - Martí Oller
+  - Anmol Sahu
+  - Cesare Giulio Ardito
+  - Yuzheng Hu
+  - Ariel Ghislain Kemogne Kamdoum
+  - Alvin Jin
+  - Tobias Garcia Vilchis
+  - Yuexuan Zu
+  - Martin Lackner
+  - James Koppel
+  - Gongbo Sun
+  - Daniil S. Antonenko
+  - Steffi Chern
+  - Bingchen Zhao
+  - Pierrot Arsene
+  - Joseph M Cavanagh
+  - Daofeng Li
+  - Jiawei Shen
+  - Donato Crisostomi
+  - Wenjin Zhang
+  - Ali Dehghan
+  - Sergey Ivanov
+  - David Perrella
+  - Nurdin Kaparov
+  - Allen Zang
+  - Ilia Sucholutsky
+  - Arina Kharlamova
+  - Daniil Orel
+  - Vladislav Poritski
+  - Shalev Ben-David
+  - Zachary Berger
+  - Parker Whitfill
+  - Michael Foster
+  - Daniel Munro
+  - Linh Ho
+  - Shankar Sivarajan
+  - Dan Bar Hava
+  - Aleksey Kuchkin
+  - David Holmes
+  - Alexandra Rodriguez-Romero
+  - Frank Sommerhage
+  - Anji Zhang
+  - Richard Moat
+  - Keith Schneider
+  - Zakayo Kazibwe
+  - Don Clarke
+  - Dae Hyun Kim
+  - Felipe Meneguitti Dias
+  - Sara Fish
+  - Veit Elser
+  - Tobias Kreiman
+  - Victor Efren Guadarrama Vilchis
+  - Immo Klose
+  - Ujjwala Anantheswaran
+  - Adam Zweiger
+  - Kaivalya Rawal
+  - Jeffery Li
+  - Jeremy Nguyen
+  - Nicolas Daans
+  - Haline Heidinger
+  - Maksim Radionov
+  - Václav Rozhoň
+  - Vincent Ginis
+  - Christian Stump
+  - Niv Cohen
+  - Rafał Poświata
+  - Josef Tkadlec
+  - Alan Goldfarb
+  - Chenguang Wang
+  - Piotr Padlewski
+  - Stanislaw Barzowski
+  - Kyle Montgomery
+  - Ryan Stendall
+  - Jamie Tucker-Foltz
+  - Jack Stade
+  - T. Ryan Rogers
+  - Tom Goertzen
+  - Declan Grabb
+  - Abhishek Shukla
+  - Alan Givré
+  - John Arnold Ambay
+  - Archan Sen
+  - Muhammad Fayez Aziz
+  - Mark H Inlow
+  - Hao He
+  - Ling Zhang
+  - Younesse Kaddar
+  - Ivar Ängquist
+  - Yanxu Chen
+  - Harrison K Wang
+  - Kalyan Ramakrishnan
+  - Elliott Thornley
+  - Antonio Terpin
+  - Hailey Schoelkopf
+  - Eric Zheng
+  - Avishy Carmi
+  - Ethan D. L. Brown
+  - Kelin Zhu
+  - Max Bartolo
+  - Richard Wheeler
+  - Martin Stehberger
+  - Peter Bradshaw
+  - JP Heimonen
+  - Kaustubh Sridhar
+  - Ido Akov
+  - Jennifer Sandlin
+  - Yury Makarychev
+  - Joanna Tam
+  - Hieu Hoang
+  - David M. Cunningham
+  - Vladimir Goryachev
+  - Demosthenes Patramanis
+  - Michael Krause
+  - Andrew Redenti
+  - David Aldous
+  - Jesyin Lai
+  - Shannon Coleman
+  - Jiangnan Xu
+  - Sangwon Lee
+  - Ilias Magoulas
+  - Sandy Zhao
+  - Ning Tang
+  - Michael K. Cohen
+  - Orr Paradise
+  - Jan Hendrik Kirchner
+  - Maksym Ovchynnikov
+  - Jason O. Matos
+  - Adithya Shenoy
+  - Michael Wang
+  - Yuzhou Nie
+  - Anna Sztyber-Betley
+  - Paolo Faraboschi
+  - Robin Riblet
+  - Jonathan Crozier
+  - Shiv Halasyamani
+  - Shreyas Verma
+  - Prashant Joshi
+  - Eli Meril
+  - Ziqiao Ma
+  - Jérémy Andréoletti
+  - Raghav Singhal
+  - Jacob Platnick
+  - Volodymyr Nevirkovets
+  - Luke Basler
+  - Alexander Ivanov
+  - Seri Khoury
+  - Nils Gustafsson
+  - Marco Piccardo
+  - Hamid Mostaghimi
+  - Qijia Chen
+  - Virendra Singh
+  - Tran Quoc Khánh
+  - Paul Rosu
+  - Hannah Szlyk
+  - Zachary Brown
+  - Himanshu Narayan
+  - Aline Menezes
+  - Jonathan Roberts
+  - William Alley
+  - Kunyang Sun
+  - Arkil Patel
+  - Max Lamparth
+  - Anka Reuel
+  - Linwei Xin
+  - Hanmeng Xu
+  - Jacob Loader
+  - Freddie Martin
+  - Zixuan Wang
+  - Andrea Achilleos
+  - Thomas Preu
+  - Tomek Korbak
+  - Ida Bosio
+  - Fereshteh Kazemi
+  - Ziye Chen
+  - Biró Bálint
+  - Eve J. Y. Lo
+  - Jiaqi Wang
+  - Maria Inês S. Nunes
+  - Jeremiah Milbauer
+  - M Saiful Bari
+  - Zihao Wang
+  - Behzad Ansarinejad
+  - Yewen Sun
+  - Stephane Durand
+  - Hossam Elgnainy
+  - Guillaume Douville
+  - Daniel Tordera
+  - George Balabanian
+  - Hew Wolff
+  - Lynna Kvistad
+  - Hsiaoyun Milliron
+  - Ahmad Sakor
+  - Murat Eron
+  - Andrew Favre D. O.
+  - Shailesh Shah
+  - Xiaoxiang Zhou
+  - Firuz Kamalov
+  - Sherwin Abdoli
+  - Tim Santens
+  - Shaul Barkan
+  - Allison Tee
+  - Robin Zhang
+  - Alessandro Tomasiello
+  - G. Bruno De Luca
+  - Shi-Zhuo Looi
+  - Vinh-Kha Le
+  - Noam Kolt
+  - Jiayi Pan
+  - Emma Rodman
+  - Jacob Drori
+  - Carl J Fossum
+  - Niklas Muennighoff
+  - Milind Jagota
+  - Ronak Pradeep
+  - Honglu Fan
+  - Jonathan Eicher
+  - Michael Chen
+  - Kushal Thaman
+  - William Merrill
+  - Moritz Firsching
+  - Carter Harris
+  - Stefan Ciobâcă
+  - Jason Gross
+  - Rohan Pandey
+  - Ilya Gusev
+  - Adam Jones
+  - Shashank Agnihotri
+  - Pavel Zhelnov
+  - Mohammadreza Mofayezi
+  - Alexander Piperski
+  - David K. Zhang
+  - Kostiantyn Dobarskyi
+  - Roman Leventov
+  - Ignat Soroko
+  - Joshua Duersch
+  - Vage Taamazyan
+  - Andrew Ho
+  - Wenjie Ma
+  - William Held
+  - Ruicheng Xian
+  - Armel Randy Zebaze
+  - Mohanad Mohamed
+  - Julian Noah Leser
+  - Michelle X Yuan
+  - Laila Yacar
+  - Johannes Lengler
+  - Katarzyna Olszewska
+  - Claudio Di Fratta
+  - Edson Oliveira
+  - Joseph W. Jackson
+  - Andy Zou
+  - Muthu Chidambaram
+  - Timothy Manik
+  - Hector Haffenden
+  - Dashiell Stander
+  - Ali Dasouqi
+  - Alexander Shen
+  - Bita Golshani
+  - David Stap
+  - Egor Kretov
+  - Mikalai Uzhou
+  - Alina Borisovna Zhidkovskaya
+  - Nick Winter
+  - Miguel Orbegozo Rodriguez
+  - Robert Lauff
+  - Dustin Wehr
+  - Colin Tang
+  - Zaki Hossain
+  - Shaun Phillips
+  - Fortuna Samuele
+  - Fredrik Ekström
+  - Angela Hammon
+  - Oam Patel
+  - Faraz Farhidi
+  - George Medley
+  - Forough Mohammadzadeh
+  - Madellene Peñaflor
+  - Haile Kassahun
+  - Alena Friedrich
+  - Rayner Hernandez Perez
+  - Daniel Pyda
+  - Taom Sakal
+  - Omkar Dhamane
+  - Ali Khajegili Mirabadi
+  - Eric Hallman
+  - Kenchi Okutsu
+  - Mike Battaglia
+  - Mohammad Maghsoudimehrabani
+  - Alon Amit
+  - Dave Hulbert
+  - Roberto Pereira
+  - Simon Weber
+  - ' Handoko'
+  - Anton Peristyy
+  - Stephen Malina
+  - Mustafa Mehkary
+  - Rami Aly
+  - Frank Reidegeld
+  - Anna-Katharina Dick
+  - Cary Friday
+  - Mukhwinder Singh
+  - Hassan Shapourian
+  - Wanyoung Kim
+  - Mariana Costa
+  - Hubeyb Gurdogan
+  - Harsh Kumar
+  - Chiara Ceconello
+  - Chao Zhuang
+  - Haon Park
+  - Micah Carroll
+  - Andrew R. Tawfeek
+  - Stefan Steinerberger
+  - Daattavya Aggarwal
+  - Michael Kirchhof
+  - Linjie Dai
+  - Evan Kim
+  - Johan Ferret
+  - Jainam Shah
+  - Yuzhou Wang
+  - Minghao Yan
+  - Krzysztof Burdzy
+  - Lixin Zhang
+  - Antonio Franca
+  - Diana T. Pham
+  - Kang Yong Loh
+  - Joshua Robinson
+  - Abram Jackson
+  - Paolo Giordano
+  - Philipp Petersen
+  - Adrian Cosma
+  - Jesus Colino
+  - Colin White
+  - Jacob Votava
+  - Vladimir Vinnikov
+  - Ethan Delaney
+  - Petr Spelda
+  - Vit Stritecky
+  - Syed M. Shahid
+  - Jean-Christophe Mourrat
+  - Lavr Vetoshkin
+  - Koen Sponselee
+  - Renas Bacho
+  - Zheng-Xin Yong
+  - Florencia de la Rosa
+  - Nathan Cho
+  - Xiuyu Li
+  - Guillaume Malod
+  - Orion Weller
+  - Guglielmo Albani
+  - Leon Lang
+  - Julien Laurendeau
+  - Dmitry Kazakov
+  - Fatimah Adesanya
+  - Julien Portier
+  - Lawrence Hollom
+  - Victor Souza
+  - Yuchen Anna Zhou
+  - Julien Degorre
+  - Yiğit Yalın
+  - Gbenga Daniel Obikoya
+  - ' Rai'
+  - Filippo Bigi
+  - M. C. Boscá
+  - Oleg Shumar
+  - Kaniuar Bacho
+  - Gabriel Recchia
+  - Mara Popescu
+  - Nikita Shulga
+  - Ngefor Mildred Tanwie
+  - Thomas C. H. Lux
+  - Ben Rank
+  - Colin Ni
+  - Matthew Brooks
+  - Alesia Yakimchyk
+  - ' Huanxu'
+  - ' Liu'
+  - Stefano Cavalleri
+  - Olle Häggström
+  - Emil Verkama
+  - Joshua Newbould
+  - Hans Gundlach
+  - Leonor Brito-Santana
+  - Brian Amaro
+  - Vivek Vajipey
+  - Rynaa Grover
+  - Ting Wang
+  - Yosi Kratish
+  - Wen-Ding Li
+  - Sivakanth Gopi
+  - Andrea Caciolai
+  - Christian Schroeder de Witt
+  - Pablo Hernández-Cámara
+  - Emanuele Rodolà
+  - Jules Robins
+  - Dominic Williamson
+  - Vincent Cheng
+  - Brad Raynor
+  - Hao Qi
+  - Ben Segev
+  - Jingxuan Fan
+  - Sarah Martinson
+  - Erik Y. Wang
+  - Kaylie Hausknecht
+  - Michael P. Brenner
+  - Mao Mao
+  - Christoph Demian
+  - Peyman Kassani
+  - Xinyu Zhang
+  - David Avagian
+  - Eshawn Jessica Scipio
+  - Alon Ragoler
+  - Justin Tan
+  - Blake Sims
+  - Rebeka Plecnik
+  - Aaron Kirtland
+  - Omer Faruk Bodur
+  - D. P. Shinde
+  - Yan Carlos Leyva Labrador
+  - Zahra Adoul
+  - Mohamed Zekry
+  - Ali Karakoc
+  - Tania C. B. Santos
+  - Samir Shamseldeen
+  - Loukmane Karim
+  - Anna Liakhovitskaia
+  - Nate Resman
+  - Nicholas Farina
+  - Juan Carlos Gonzalez
+  - Gabe Maayan
+  - Earth Anderson
+  - Rodrigo De Oliveira Pena
+  - Elizabeth Kelley
+  - Hodjat Mariji
+  - Rasoul Pouriamanesh
+  - Wentao Wu
+  - Ross Finocchio
+  - Ismail Alarab
+  - Joshua Cole
+  - Danyelle Ferreira
+  - Bryan Johnson
+  - Mohammad Safdari
+  - Liangti Dai
+  - Siriphan Arthornthurasuk
+  - Isaac C. McAlister
+  - Alejandro José Moyano
+  - Alexey Pronin
+  - Jing Fan
+  - Angel Ramirez-Trinidad
+  - Yana Malysheva
+  - Daphiny Pottmaier
+  - Omid Taheri
+  - Stanley Stepanic
+  - Samuel Perry
+  - Luke Askew
+  - Raúl Adrián Huerta Rodríguez
+  - Ali M. R. Minissi
+  - Ricardo Lorena
+  - Krishnamurthy Iyer
+  - Arshad Anil Fasiludeen
+  - Ronald Clark
+  - Josh Ducey
+  - Matheus Piza
+  - Maja Somrak
+  - Eric Vergo
+  - Juehang Qin
+  - Benjámin Borbás
+  - Eric Chu
+  - Jack Lindsey
+  - Antoine Jallon
+  - I. M. J. McInnis
+  - Evan Chen
+  - Avi Semler
+  - Luk Gloor
+  - Tej Shah
+  - Marc Carauleanu
+  - Pascal Lauer
+  - Tran Đuc Huy
+  - Hossein Shahrtash
+  - Emilien Duc
+  - Lukas Lewark
+  - Assaf Brown
+  - Samuel Albanie
+  - Brian Weber
+  - Warren S. Vaz
+  - Pierre Clavier
+  - Yiyang Fan
+  - Gabriel Poesia Reis e Silva
+  - ' Long'
+  - ' Lian'
+  - Marcus Abramovitch
+  - Xi Jiang
+  - Sandra Mendoza
+  - Murat Islam
+  - Juan Gonzalez
+  - Vasilios Mavroudis
+  - Justin Xu
+  - Pawan Kumar
+  - Laxman Prasad Goswami
+  - Daniel Bugas
+  - Nasser Heydari
+  - Ferenc Jeanplong
+  - Thorben Jansen
+  - Antonella Pinto
+  - Archimedes Apronti
+  - Abdallah Galal
+  - Ng Ze-An
+  - Ankit Singh
+  - Tong Jiang
+  - Joan of Arc Xavier
+  - Kanu Priya Agarwal
+  - Mohammed Berkani
+  - Gang Zhang
+  - Zhehang Du
+  - Benedito Alves de Oliveira Junior
+  - Dmitry Malishev
+  - Nicolas Remy
+  - Taylor D. Hartman
+  - Tim Tarver
+  - Stephen Mensah
+  - Gautier Abou Loume
+  - Wiktor Morak
+  - Farzad Habibi
+  - Sarah Hoback
+  - Will Cai
+  - Javier Gimenez
+  - Roselynn Grace Montecillo
+  - Jakub Łucki
+  - Russell Campbell
+  - Asankhaya Sharma
+  - Khalida Meer
+  - Shreen Gul
+  - Daniel Espinosa Gonzalez
+  - Xavier Alapont
+  - Alex Hoover
+  - Gunjan Chhablani
+  - Freddie Vargus
+  - Arunim Agarwal
+  - Yibo Jiang
+  - Deepakkumar Patil
+  - David Outevsky
+  - Kevin Joseph Scaria
+  - Rajat Maheshwari
+  - Abdelkader Dendane
+  - Priti Shukla
+  - Ashley Cartwright
+  - Sergei Bogdanov
+  - Niels Mündler
+  - Sören Möller
+  - Luca Arnaboldi
+  - Kunvar Thaman
+  - Muhammad Rehan Siddiqi
+  - Prajvi Saxena
+  - Himanshu Gupta
+  - Tony Fruhauff
+  - Glen Sherman
+  - Mátyás Vincze
+  - Siranut Usawasutsakorn
+  - Dylan Ler
+  - Anil Radhakrishnan
+  - Innocent Enyekwe
+  - Sk Md Salauddin
+  - Jiang Muzhen
+  - Aleksandr Maksapetyan
+  - Vivien Rossbach
+  - Chris Harjadi
+  - Mohsen Bahaloohoreh
+  - Claire Sparrow
+  - Jasdeep Sidhu
+  - Sam Ali
+  - Song Bian
+  - John Lai
+  - Eric Singer
+  - Justine Leon Uro
+  - Greg Bateman
+  - Mohamed Sayed
+  - Ahmed Menshawy
+  - Darling Duclosel
+  - Dario Bezzi
+  - Yashaswini Jain
+  - Ashley Aaron
+  - Murat Tiryakioglu
+  - Sheeshram Siddh
+  - Keith Krenek
+  - Imad Ali Shah
+  - Jun Jin
+  - Scott Creighton
+  - Denis Peskoff
+  - Zienab EL-Wasif
+  - Ragavendran P
+  - Michael Richmond
+  - Joseph McGowan
+  - Tejal Patwardhan
+  - Hao-Yu Sun
+  - Ting Sun
+  - Nikola Zubić
+  - Samuele Sala
+  - Stephen Ebert
+  - Jean Kaddour
+  - Manuel Schottdorf
+  - Dianzhuo Wang
+  - Gerol Petruzella
+  - Alex Meiburg
+  - Tilen Medved
+  - Ali ElSheikh
+  - S Ashwin Hebbar
+  - Lorenzo Vaquero
+  - Xianjun Yang
+  - Jason Poulos
+  - Vilém Zouhar
+  - Sergey Bogdanik
+  - Mingfang Zhang
+  - Jorge Sanz-Ros
+  - David Anugraha
+  - Yinwei Dai
+  - Anh N. Nhu
+  - Xue Wang
+  - Ali Anil Demircali
+  - Zhibai Jia
+  - Yuyin Zhou
+  - Juncheng Wu
+  - Mike He
+  - Nitin Chandok
+  - Aarush Sinha
+  - Gaoxiang Luo
+  - Long Le
+  - Mickaël Noyé
+  - Michał Perełkiewicz
+  - Ioannis Pantidis
+  - Tianbo Qi
+  - Soham Sachin Purohit
+  - Letitia Parcalabescu
+  - Thai-Hoa Nguyen
+  - Genta Indra Winata
+  - Edoardo M. Ponti
+  - Hanchen Li
+  - Kaustubh Dhole
+  - Jongee Park
+  - Dario Abbondanza
+  - Yuanli Wang
+  - Anupam Nayak
+  - Diogo M. Caetano
+  - Antonio A. W. L. Wong
+  - Maria del Rio-Chanona
+  - Dániel Kondor
+  - Pieter Francois
+  - Ed Chalstrey
+  - Jakob Zsambok
+  - Dan Hoyer
+  - Jenny Reddish
+  - Jakob Hauser
+  - Francisco-Javier Rodrigo-Ginés
+  - Suchandra Datta
+  - Maxwell Shepherd
+  - Thom Kamphuis
+  - Qizheng Zhang
+  - Hyunjun Kim
+  - Ruiji Sun
+  - Jianzhu Yao
+  - Franck Dernoncourt
+  - Satyapriya Krishna
+  - Sina Rismanchian
+  - Bonan Pu
+  - Francesco Pinto
+  - Yingheng Wang
+  - Kumar Shridhar
+  - Kalon J. Overholt
+  - Glib Briia
+  - Hieu Nguyen
+  - ' David'
+  - Soler Bartomeu
+  - Tony CY Pang
+  - Adam Wecker
+  - Yifan Xiong
+  - Fanfei Li
+  - Lukas S. Huber
+  - Joshua Jaeger
+  - Romano De Maddalena
+  - Xing Han Lù
+  - Yuhui Zhang
+  - Claas Beger
+  - Patrick Tser Jern Kon
+  - Sean Li
+  - Vivek Sanker
+  - Ming Yin
+  - Yihao Liang
+  - Xinlu Zhang
+  - Ankit Agrawal
+  - Li S. Yifei
+  - Zechen Zhang
+  - Mu Cai
+  - Yasin Sonmez
+  - Costin Cozianu
+  - Changhao Li
+  - Alex Slen
+  - Shoubin Yu
+  - Hyun Kyu Park
+  - Gabriele Sarti
+  - Marcin Briański
+  - Alessandro Stolfo
+  - Truong An Nguyen
+  - Mike Zhang
+  - Yotam Perlitz
+  - Jose Hernandez-Orallo
+  - Runjia Li
+  - Amin Shabani
+  - Felix Juefei-Xu
+  - Shikhar Dhingra
+  - Orr Zohar
+  - My Chiffon Nguyen
+  - Alexander Pondaven
+  - Abdurrahim Yilmaz
+  - Xuandong Zhao
+  - Chuanyang Jin
+  - Muyan Jiang
+  - Stefan Todoran
+  - Xinyao Han
+  - Jules Kreuer
+  - Brian Rabern
+  - Anna Plassart
+  - Martino Maggetti
+  - Luther Yap
+  - Robert Geirhos
+  - Jonathon Kean
+  - Dingsu Wang
+  - Sina Mollaei
+  - Chenkai Sun
+  - Yifan Yin
+  - Shiqi Wang
+  - Rui Li
+  - Yaowen Chang
+  - Anjiang Wei
+  - Alice Bizeul
+  - Xiaohan Wang
+  - Alexandre Oliveira Arrais
+  - Kushin Mukherjee
+  - Jorge Chamorro-Padial
+  - Jiachen Liu
+  - Xingyu Qu
+  - Junyi Guan
+  - Adam Bouyamourn
+  - Shuyu Wu
+  - Martyna Plomecka
+  - Junda Chen
+  - Mengze Tang
+  - Jiaqi Deng
+  - Shreyas Subramanian
+  - Haocheng Xi
+  - Haoxuan Chen
+  - Weizhi Zhang
+  - Yinuo Ren
+  - Haoqin Tu
+  - Sejong Kim
+  - Yushun Chen
+  - Sara Vera Marjanović
+  - Junwoo Ha
+  - Grzegorz Luczyna
+  - Jeff J. Ma
+  - Zewen Shen
+  - Dawn Song
+  - Cedegao E. Zhang
+  - Zhun Wang
+  - Gaël Gendron
+  - Yunze Xiao
+  - Leo Smucker
+  - Erica Weng
+  - Kwok Hao Lee
+  - Zhe Ye
+  - Stefano Ermon
+  - Ignacio D. Lopez-Miguel
+  - Theo Knights
+  - Anthony Gitter
+  - Namkyu Park
+  - Boyi Wei
+  - Hongzheng Chen
+  - Kunal Pai
+  - Ahmed Elkhanany
+  - Han Lin
+  - Philipp D. Siedler
+  - Jichao Fang
+  - Ritwik Mishra
+  - Károly Zsolnai-Fehér
+  - Xilin Jiang
+  - Shadab Khan
+  - Jun Yuan
+  - Rishab Kumar Jain
+  - Xi Lin
+  - Mike Peterson
+  - Zhe Wang
+  - Aditya Malusare
+  - Maosen Tang
+  - Isha Gupta
+  - Ivan Fosin
+  - Timothy Kang
+  - Barbara Dworakowska
+  - Kazuki Matsumoto
+  - Guangyao Zheng
+  - Gerben Sewuster
+  - Jorge Pretel Villanueva
+  - Ivan Rannev
+  - Igor Chernyavsky
+  - Jiale Chen
+  - Deepayan Banik
+  - Ben Racz
+  - Wenchao Dong
+  - Jianxin Wang
+  - Laila Bashmal
+  - Duarte V. Gonçalves
+  - Wei Hu
+  - Kaushik Bar
+  - Ondrej Bohdal
+  - Atharv Singh Patlan
+  - Shehzaad Dhuliawala
+  - Caroline Geirhos
+  - Julien Wist
+  - Yuval Kansal
+  - Bingsen Chen
+  - Kutay Tire
+  - Atak Talay Yücel
+  - Brandon Christof
+  - Veerupaksh Singla
+  - Zijian Song
+  - Sanxing Chen
+  - Jiaxin Ge
+  - Kaustubh Ponkshe
+  - Isaac Park
+  - Tianneng Shi
+  - Martin Q. Ma
+  - Joshua Mak
+  - Sherwin Lai
+  - Antoine Moulin
+  - Zhuo Cheng
+  - Zhanda Zhu
+  - Ziyi Zhang
+  - Vaidehi Patil
+  - Ketan Jha
+  - Qiutong Men
+  - Jiaxuan Wu
+  - Tianchi Zhang
+  - Bruno Hebling Vieira
+  - Alham Fikri Aji
+  - Jae-Won Chung
+  - Mohammed Mahfoud
+  - Ha Thi Hoang
+  - Marc Sperzel
+  - Wei Hao
+  - Kristof Meding
+  - Sihan Xu
+  - Vassilis Kostakos
+  - Davide Manini
+  - Yueying Liu
+  - Christopher Toukmaji
+  - Jay Paek
+  - Eunmi Yu
+  - Arif Engin Demircali
+  - Zhiyi Sun
+  - Ivan Dewerpe
+  - Hongsen Qin
+  - Roman Pflugfelder
+  - James Bailey
+  - Johnathan Morris
+  - Ville Heilala
+  - Sybille Rosset
+  - Zishun Yu
+  - Peter E. Chen
+  - Woongyeong Yeo
+  - Eeshaan Jain
+  - Ryan Yang
+  - Sreekar Chigurupati
+  - Julia Chernyavsky
+  - Sai Prajwal Reddy
+  - Subhashini Venugopalan
+  - Hunar Batra
+  - Core Francisco Park
+  - Hieu Tran
+  - Guilherme Maximiano
+  - Genghan Zhang
+  - Yizhuo Liang
+  - Hu Shiyu
+  - Rongwu Xu
+  - Rui Pan
+  - Siddharth Suresh
+  - Ziqi Liu
+  - Samaksh Gulati
+  - Songyang Zhang
+  - Peter Turchin
+  - Christopher W. Bartlett
+  - Christopher R. Scotese
+  - Phuong M. Cao
+  - Ben Wu
+  - Jacek Karwowski
+  - Davide Scaramuzza
+  - Aakaash Nattanmai
+  - Gordon McKellips
+  - Anish Cheraku
+  - Asim Suhail
+  - Ethan Luo
+  - Marvin Deng
+  - Jason Luo
+  - Ashley Zhang
+  - Kavin Jindel
+  - Jay Paek
+  - Kasper Halevy
+  - Allen Baranov
+  - Michael Liu
+  - Advaith Avadhanam
+  - David Zhang
+  - Vincent Cheng
+  - Brad Ma
+  - Evan Fu
+  - Liam Do
+  - Joshua Lass
+  - Hubert Yang
+  - Surya Sunkari
+  - Vishruth Bharath
+  - Violet Ai
+  - James Leung
+  - Rishit Agrawal
+  - Alan Zhou
+  - Kevin Chen
+  - Tejas Kalpathi
+  - Ziqi Xu
+  - Gavin Wang
+  - Tyler Xiao
+  - Erik Maung
+  - Sam Lee
+  - Ryan Yang
+  - Roy Yue
+  - Ben Zhao
+  - Julia Yoon
+  - Sunny Sun
+  - Aryan Singh
+  - Ethan Luo
+  - Clark Peng
+  - Tyler Osbey
+  - Taozhi Wang
+  - Daryl Echeazu
+  - Hubert Yang
+  - Timothy Wu
+  - Spandan Patel
+  - Vidhi Kulkarni
+  - Vijaykaarti Sundarapandiyan
+  - Ashley Zhang
+  - Andrew Le
+  - Zafir Nasim
+  - Srikar Yalam
+  - Ritesh Kasamsetty
+  - Soham Samal
+  - Hubert Yang
+  - David Sun
+  - Nihar Shah
+  - Abhijeet Saha
+  - Alex Zhang
+  - Leon Nguyen
+  - Laasya Nagumalli
+  - Kaixin Wang
+  - Alan Zhou
+  - Aidan Wu
+  - Jason Luo
+  - Anwith Telluri
+  - Steven Dillmann
+  - Zhengxiang Wang
+  - Junyu Luo
+  - Hugo Lunn
+  - Artem Gazizov
+  - Haitz Sáez de Ocáriz Borde
+  - Ivan Trus
+  - Morgan Hervault
+  - Zheyu Zhang
+  - Bo Chen
+  - Yuchen Wu
+  - Christopher J. Cordier
+  - Gün Kaynar
+  - Cansin Ayvaz
+  - Polina Avdiunina
+  - Johannes Brust
+  - Xingjian Diao
+  - K. D. Meaney
+  - Yifan Gu
+  - Chenyu Wang
+  - Chenzhuo Dong
+  - William Wright
+  - Simon Brave
+  - Owen Root
+  - Jiayuan Liu
+  - Chow Chun Lok
+  - Tianqin Li
+  - Shiyi Du
+  - Dailan He
+  - Lufeiya Liu
+  - Sina Jamalzadegan
+  - Anil Ramakrishna
+  - Xuanqing Xu
+  - Xin Qing
+  - Xin Luo
+  - Wenkai Li
+  - Shi Bo
+  - Filipp Gusev
+  - Maximos Skandalis
+  - Desheng Ma
+  - Chunhui Zhang
+  - Haoran Qiu
+  - Allen G Hart
+  - Rickard Brüel Gabrielsson
+  - Ido Akov
+  - Artem Lukoianov
+  - Summer Yue
+  - Alexandr Wang
+  - Dan Hendrycks
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2412.21187
+  title: Do NOT Think That Much for 2+3=? On the Overthinking of o1-Like LLMs
+  date: '2024-12-30'
+  updated: '2025-02-01'
+  url: https://arxiv.org/abs/2412.21187
+  abstract: 'The remarkable performance of models like the OpenAI o1 can be attributed to their ability to emulate human-like
+    long-time thinking during inference. These models employ extended chain-of-thought (CoT) processes, exploring multiple
+    strategies to enhance problem-solving capabilities. However, a critical question remains: How to intelligently and efficiently
+    scale computational resources during testing. This paper presents the first comprehensive study on the prevalent issue
+    of overthinking in these models, where excessive computational resources are allocated for simple problems with minimal
+    benefit. We introduce novel efficiency metrics from both outcome and process perspectives to evaluate the rational use
+    of computational resources by o1-like models. Using a self-training paradigm, we propose strategies to mitigate overthinking,
+    streamlining reasoning processes without compromising accuracy. Experimental results show that our approach successfully
+    reduces computational overhead while preserving model performance across a range of testsets with varying difficulty levels,
+    such as GSM8K, MATH500, GPQA, and AIME.'
+  authors:
+  - Xingyu Chen
+  - Jiahao Xu
+  - Tian Liang
+  - Zhiwei He
+  - Jianhui Pang
+  - Dian Yu
+  - Linfeng Song
+  - Qiuzhi Liu
+  - Mengfei Zhou
+  - Zhuosheng Zhang
+  - Rui Wang
+  - Zhaopeng Tu
+  - Haitao Mi
+  - Dong Yu
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2412.10673
+  title: Proposing and solving olympiad geometry with guided tree search
+  date: '2024-12-14'
+  updated: '2024-12-14'
+  url: https://arxiv.org/abs/2412.10673
+  abstract: 'Mathematics olympiads are prestigious competitions, with problem proposing and solving highly honored. Building
+    artificial intelligence that proposes and solves olympiads presents an unresolved challenge in automated theorem discovery
+    and proving, especially in geometry for its combination of numerical and spatial elements. We introduce TongGeometry,
+    a Euclidean geometry system supporting tree-search-based guided problem proposing and solving. The efficient geometry
+    system establishes the most extensive repository of geometry theorems to date: within the same computational budget as
+    the existing state-of-the-art, TongGeometry discovers 6.7 billion geometry theorems requiring auxiliary constructions,
+    including 4.1 billion exhibiting geometric symmetry. Among them, 10 theorems were proposed to regional mathematical olympiads
+    with 3 of TongGeometry''s proposals selected in real competitions, earning spots in a national team qualifying exam or
+    a top civil olympiad in China and the US. Guided by fine-tuned large language models, TongGeometry solved all International
+    Mathematical Olympiad geometry in IMO-AG-30, outperforming gold medalists for the first time. It also surpasses the existing
+    state-of-the-art across a broader spectrum of olympiad-level problems. The full capabilities of the system can be utilized
+    on a consumer-grade machine, making the model more accessible and fostering widespread democratization of its use. By
+    analogy, unlike existing systems that merely solve problems like students, TongGeometry acts like a geometry coach, discovering,
+    presenting, and proving theorems.'
+  authors:
+  - Chi Zhang
+  - Jiajun Song
+  - Siyu Li
+  - Yitao Liang
+  - Yuxi Ma
+  - Wei Wang
+  - Yixin Zhu
+  - Song-Chun Zhu
+  arxiv_categories:
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2411.04459
+  title: GPT-Guided Monte Carlo Tree Search for Symbolic Regression in Financial Fraud Detection
+  date: '2024-11-07'
+  updated: '2024-11-07'
+  url: https://arxiv.org/abs/2411.04459
+  abstract: With the increasing number of financial services available online, the rate of financial fraud has also been increasing.
+    The traffic and transaction rates on the internet have increased considerably, leading to a need for fast decision-making.
+    Financial institutions also have stringent regulations that often require transparency and explainability of the decision-making
+    process. However, most state-of-the-art algorithms currently used in the industry are highly parameterized black-box models
+    that rely on complex computations to generate a score. These algorithms are inherently slow and lack the explainability
+    and speed of traditional rule-based learners. This work introduces SR-MCTS (Symbolic Regression MCTS), which utilizes
+    a foundational GPT model to guide the MCTS, significantly enhancing its convergence speed and the quality of the generated
+    expressions which are further extracted to rules. Our experiments show that SR-MCTS can detect fraud more efficiently
+    than widely used methods in the industry while providing substantial insights into the decision-making process.
+  authors:
+  - Prashank Kadam
+  arxiv_categories:
+  - cs.CE
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2410.23743
+  title: 'What Happened in LLMs Layers when Trained for Fast vs. Slow Thinking: A Gradient Perspective'
+  date: '2024-10-31'
+  updated: '2025-06-05'
+  url: https://arxiv.org/abs/2410.23743
+  abstract: 'What makes a difference in the post-training of LLMs? We investigate the training patterns of different layers
+    in large language models (LLMs) through the lens of the gradient. We are specifically interested in how fast vs. slow
+    thinking affects the layer-wise gradients, given the recent popularity of training LLMs on reasoning paths such as chain-of-thoughts
+    (CoT) and process rewards. In our study, fast thinking without CoT leads to larger gradients and larger differences of
+    gradients across layers than slow thinking (Detailed CoT), indicating the learning stability brought by the latter. Additionally,
+    we study whether the gradient patterns can reflect the correctness of responses when training different LLMs using slow
+    vs. fast thinking paths. The results show that the gradients of slow thinking can distinguish correct and irrelevant reasoning
+    paths. As a comparison, we conduct similar gradient analyses on non-reasoning knowledge learning tasks, on which, however,
+    trivially increasing the response length does not lead to similar behaviors of slow thinking. Our study strengthens fundamental
+    understandings of LLM training and sheds novel insights on its efficiency and stability, which pave the way towards building
+    a generalizable System-2 agent. Our code, data, and gradient statistics can be found in: https://github.com/MingLiiii/Layer_Gradient.'
+  authors:
+  - Ming Li
+  - Yanhong Li
+  - Tianyi Zhou
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2410.17820
+  title: 'Understanding When Tree of Thoughts Succeeds: Larger Models Excel in Generation, Not Discrimination'
+  date: '2024-10-23'
+  updated: '2024-10-24'
+  url: https://arxiv.org/abs/2410.17820
+  abstract: Tree of Thoughts (ToT) is a reasoning strategy for Large Language Models (LLMs) that employs a generator to suggest
+    reasoning steps and a discriminator to decide which steps to implement. ToT demonstrates strong performance on reasoning
+    tasks, often surpassing simple methods such as Input-Output (IO) prompting and Chain-of-Thought (CoT) reasoning. However,
+    ToT does not consistently outperform such simpler methods across all models, leaving large knowledge gaps on the conditions
+    under which ToT is most beneficial. In this paper, we analyze the roles of the generator and discriminator separately
+    to better understand the conditions when ToT is beneficial. We find that the generator plays a more critical role than
+    the discriminator in driving the success of ToT. Scaling the generator leads to notable improvements in ToT performance,
+    even when using a smaller model as the discriminator, whereas scaling the discriminator with a fixed generator yields
+    only marginal gains. Our results show that models across different scales exhibit comparable discrimination capabilities,
+    yet differ significantly in their generative performance for ToT.
+  authors:
+  - Qiqi Chen
+  - Xinpeng Wang
+  - Philipp Mondorf
+  - Michael A. Hedderich
+  - Barbara Plank
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2409.15277
+  title: 'A Preliminary Study of o1 in Medicine: Are We Closer to an AI Doctor?'
+  date: '2024-09-23'
+  updated: '2024-09-23'
+  url: https://arxiv.org/abs/2409.15277
+  abstract: 'Large language models (LLMs) have exhibited remarkable capabilities across various domains and tasks, pushing
+    the boundaries of our knowledge in learning and cognition. The latest model, OpenAI''s o1, stands out as the first LLM
+    with an internalized chain-of-thought technique using reinforcement learning strategies. While it has demonstrated surprisingly
+    strong capabilities on various general language tasks, its performance in specialized fields such as medicine remains
+    unknown. To this end, this report provides a comprehensive exploration of o1 on different medical scenarios, examining
+    3 key aspects: understanding, reasoning, and multilinguality. Specifically, our evaluation encompasses 6 tasks using data
+    from 37 medical datasets, including two newly constructed and more challenging question-answering (QA) tasks based on
+    professional medical quizzes from the New England Journal of Medicine (NEJM) and The Lancet. These datasets offer greater
+    clinical relevance compared to standard medical QA benchmarks such as MedQA, translating more effectively into real-world
+    clinical utility. Our analysis of o1 suggests that the enhanced reasoning ability of LLMs may (significantly) benefit
+    their capability to understand various medical instructions and reason through complex clinical scenarios. Notably, o1
+    surpasses the previous GPT-4 in accuracy by an average of 6.2% and 6.6% across 19 datasets and two newly created complex
+    QA scenarios. But meanwhile, we identify several weaknesses in both the model capability and the existing evaluation protocols,
+    including hallucination, inconsistent multilingual ability, and discrepant metrics for evaluation. We release our raw
+    data and model outputs at https://ucsc-vlaa.github.io/o1_medicine/ for future research.'
+  authors:
+  - Yunfei Xie
+  - Juncheng Wu
+  - Haoqin Tu
+  - Siwei Yang
+  - Bingchen Zhao
+  - Yongshuo Zong
+  - Qiao Jin
+  - Cihang Xie
+  - Yuyin Zhou
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - unclassified
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2603.14972
+  title: 'Learning from Mistakes: Post-Training for Driving VLA with Takeover Data'
+  date: '2026-03-16'
+  updated: '2026-03-16'
+  url: https://arxiv.org/abs/2603.14972
+  abstract: 'Current Vision-Language-Action (VLA) paradigms in end-to-end autonomous driving rely on offline training from
+    static datasets, leaving them vulnerable to distribution shift. Recent post-training methods use takeover data to mitigate
+    this by augmenting the dataset with high-quality expert takeover samples, yet they suffer from two key limitations: supervision
+    restricted to the period after the takeover moments leads to policies with limited safety margins, and passive preference
+    optimization lacks active exploration for optimal performance. In this paper, we propose TakeVLA, a novel VLA post-training
+    framework that overcomes these shortcomings through two complementary innovations. First, we introduce pre-takeover language
+    supervision, which allows the VLA to learn from mistakes proactively. By explicitly teaching the model about what to do
+    in error-prone situations, we cultivate a precautionary mindset that anticipates hazards early and substantially enlarges
+    safety margins. Second, we propose Scenario Dreaming, a reinforcement fine-tuning paradigm that operates in reconstruceted
+    takeover scenarios, encouraging active exploration beyond mere preference fitting. Experiments on the Bench2Drive benchmark
+    demonstrate that TakeVLA achieves state-of-the-art closed-loop performance, surpassing the strong VLA baseline SimLingo
+    by 4.93 in driving score, with an enhanced safety margin as evidenced by an 11.76% increase in average TTC.'
+  authors:
+  - Yinfeng Gao
+  - Deqing Liu
+  - Qichao Zhang
+  - Yupeng Zheng
+  - Haochen Tian
+  - Guang Li
+  - Hangjun Ye
+  - Long Chen
+  - Da-Wei Ding
+  - Dongbin Zhao
+  arxiv_categories:
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2603.06577
+  title: 'Omni-Diffusion: Unified Multimodal Understanding and Generation with Masked Discrete Diffusion'
+  date: '2026-03-06'
+  updated: '2026-07-03'
+  url: https://arxiv.org/abs/2603.06577
+  abstract: 'While recent multimodal large language models (MLLMs) have made impressive strides, they predominantly employ
+    a conventional autoregressive architecture as their backbone, leaving significant room to explore effective and efficient
+    alternatives in architectural design. Concurrently, recent studies have successfully applied discrete diffusion models
+    to various domains, such as visual understanding and image generation, revealing their considerable potential as a promising
+    backbone for multimodal systems. Drawing inspiration from these pioneering studies, we introduce Omni-Diffusion, the first
+    any-to-any multimodal language model built entirely on mask-based discrete diffusion models, which unifies understanding
+    and generation across text, speech, and images. Omni-Diffusion employs a unified mask-based discrete diffusion model to
+    directly capture the joint distribution over discrete multimodal tokens. This approach supports not only bimodal tasks
+    but also more complex scenarios involving multiple modalities. On a diverse set of benchmarks, our method outperforms
+    or performs on par with existing multimodal systems that process two or more modalities, highlighting the significant
+    promise of diffusion models in powering the next generation of multimodal foundation models. Project webpage: https://omni-diffusion.github.io.'
+  authors:
+  - Lijiang Li
+  - Zuwei Long
+  - Yunhang Shen
+  - Heting Gao
+  - Haoyu Cao
+  - Xing Sun
+  - Caifeng Shan
+  - Ran He
+  - Chaoyou Fu
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2603.01063
+  title: Unleashing VLA Potentials in Autonomous Driving via Explicit Learning from Failures
+  date: '2026-03-01'
+  updated: '2026-03-01'
+  url: https://arxiv.org/abs/2603.01063
+  abstract: Vision-Language-Action (VLA) models for autonomous driving often hit a performance plateau during Reinforcement
+    Learning (RL) optimization. This stagnation arises from exploration capabilities constrained by previous Supervised Fine-Tuning
+    (SFT), leading to persistent failures in long-tail scenarios. In these critical situations, all explored actions yield
+    a zero-value driving score. This information-sparse reward signals a failure, yet fails to identify its root cause --
+    whether it is due to incorrect planning, flawed reasoning, or poor trajectory execution. To address this limitation, we
+    propose VLA with Explicit Learning from Failures (ELF-VLA), a framework that augments RL with structured diagnostic feedback.
+    Instead of relying on a vague scalar reward, our method produces detailed, interpretable reports that identify the specific
+    failure mode. The VLA policy then leverages this explicit feedback to generate a Feedback-Guided Refinement. By injecting
+    these corrected, high-reward samples back into the RL training batch, our approach provides a targeted gradient, which
+    enables the policy to solve critical scenarios that unguided exploration cannot. Extensive experiments demonstrate that
+    our method unlocks the latent capabilities of VLA models, achieving state-of-the-art (SOTA) performance on the public
+    NAVSIM benchmark for overall PDMS, EPDMS score and high-level planning accuracy.
+  authors:
+  - Yuechen Luo
+  - Qimao Chen
+  - Fang Li
+  - Shaoqing Xu
+  - Jaxin Liu
+  - Ziying Song
+  - Zhi-xin Yang
+  - Fuxi Wen
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2602.22801
+  title: Unleashing the Potential of Diffusion Models for End-to-End Autonomous Driving
+  date: '2026-02-26'
+  updated: '2026-05-16'
+  url: https://arxiv.org/abs/2602.22801
+  abstract: Diffusion models have become a popular choice for decision-making tasks in robotics, and more recently, are also
+    being considered for solving autonomous driving tasks. However, their applications and evaluations in autonomous driving
+    remain limited to simulation-based or laboratory settings. The full strength of diffusion models for large-scale, complex
+    real-world settings, such as End-to-End Autonomous Driving (E2E AD), remains underexplored. In this study, we conducted
+    a systematic and large-scale investigation to unleash the potential of the diffusion models as planners for E2E AD, based
+    on a tremendous amount of real-vehicle data and road testing. Through comprehensive and carefully controlled studies,
+    we identify key insights into the diffusion loss space, trajectory representation, and data scaling that significantly
+    impact E2E planning performance. Moreover, we also provide an effective reinforcement learning post-training strategy
+    to further enhance the safety and robustness of the learned planner. The resulting diffusion-based learning framework,
+    Hyper Diffusion Planner (HDP), is deployed on a real-vehicle platform and evaluated across 6 urban driving scenarios and
+    200 km of real-world testing, achieving a notable 10x performance improvement over the base model. Our work demonstrates
+    that diffusion models, when properly designed and trained, can serve as effective and scalable E2E AD planners for complex,
+    real-world autonomous driving tasks.
+  authors:
+  - Yinan Zheng
+  - Tianyi Tan
+  - Bin Huang
+  - Enguang Liu
+  - Ruiming Liang
+  - Jianlin Zhang
+  - Jianwei Cui
+  - Guang Chen
+  - Kun Ma
+  - Hangjun Ye
+  - Long Chen
+  - Ya-Qin Zhang
+  - Xianyuan Zhan
+  - Jingjing Liu
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2602.21472
+  title: The Design Space of Tri-Modal Masked Diffusion Models
+  date: '2026-02-25'
+  updated: '2026-02-25'
+  url: https://arxiv.org/abs/2602.21472
+  abstract: Discrete diffusion models have emerged as strong alternatives to autoregressive language models, with recent work
+    initializing and fine-tuning a base unimodal model for bimodal generation. Diverging from previous approaches, we introduce
+    the first tri-modal masked diffusion model pretrained from scratch on text, image-text, and audio-text data. We systematically
+    analyze multimodal scaling laws, modality mixing ratios, noise schedules, and batch-size effects, and we provide optimized
+    inference sampling defaults. Our batch-size analysis yields a novel stochastic differential equation (SDE)-based reparameterization
+    that eliminates the need for tuning the optimal batch size as reported in recent work. This reparameterization decouples
+    the physical batch size, often chosen based on compute constraints (GPU saturation, FLOP efficiency, wall-clock time),
+    from the logical batch size, chosen to balance gradient variance during stochastic optimization. Finally, we pretrain
+    a preliminary 3B-parameter tri-modal model on 6.4T tokens, demonstrating the capabilities of a unified design and achieving
+    strong results in text generation, text-to-image tasks, and text-to-speech tasks. Our work represents the largest-scale
+    systematic open study of multimodal discrete diffusion models conducted to date, providing insights into scaling behaviors
+    across multiple modalities.
+  authors:
+  - Louis Bethune
+  - Victor Turrisi
+  - Bruno Kacper Mlodozeniec
+  - Pau Rodriguez Lopez
+  - Lokesh Boominathan
+  - Nikhil Bhendawade
+  - Amitis Shidani
+  - Joris Pelemans
+  - Theo X. Olausson
+  - Devon Hjelm
+  - Paul Dixon
+  - Joao Monteiro
+  - Pierre Ablin
+  - Vishnu Banna
+  - Arno Blaas
+  - Nick Henderson
+  - Kari Noriy
+  - Dan Busbridge
+  - Josh Susskind
+  - Marco Cuturi
+  - Irina Belousova
+  - Luca Zappella
+  - Russ Webb
+  - Jason Ramapuram
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2602.17688
+  title: 'AnCoder: Anchored Code Generation via Discrete Diffusion Models'
+  date: '2026-02-05'
+  updated: '2026-02-05'
+  url: https://arxiv.org/abs/2602.17688
+  abstract: Diffusion language models offer a compelling alternative to autoregressive code generation, enabling global planning
+    and iterative refinement of complex program logic. However, existing approaches fail to respect the rigid structure of
+    programming languages and, as a result, often produce broken programs that fail to execute. To address this, we introduce
+    AnchorTree, a framework that explicitly anchors the diffusion process using structured, hierarchical priors native to
+    code. Specifically, AnchorTree uses the abstract syntax tree to prioritize resolving syntactically and semantically salient
+    tokens, such as keywords (e.g., if, while) and identifiers (e.g., variable names), thereby establishing a structural scaffold
+    that guides the remaining generation. We validate this framework via AnCoder, a family of models showing that structurally
+    anchored diffusion offers a parameter-efficient path to high-quality code generation.
+  authors:
+  - Anton Xue
+  - Litu Rout
+  - Constantine Caramanis
+  - Sanjay Shakkottai
+  arxiv_categories:
+  - cs.LG
+  - cs.PL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2602.14147
+  title: 'LaViDa-R1: Advancing Reasoning for Unified Multimodal Diffusion Language Models'
+  date: '2026-02-15'
+  updated: '2026-07-07'
+  url: https://arxiv.org/abs/2602.14147
+  abstract: Diffusion language models (dLLMs) recently emerged as a promising alternative to auto-regressive LLMs. The latest
+    works further extended it to multimodal understanding and generation tasks. In this work, we propose LaViDa-R1, a multimodal,
+    general-purpose reasoning dLLM. Unlike existing works that build reasoning dLLMs through task-specific reinforcement learning,
+    LaViDa-R1 incorporates diverse multimodal understanding and generation tasks in a unified manner. In particular, LaViDa-R1
+    is built with a novel unified post-training framework that seamlessly integrates supervised finetuning (SFT) and multi-task
+    reinforcement learning (RL). It employs several novel training techniques, including answer-forcing, tree search, and
+    complementary likelihood estimation, to enhance effectiveness and scalability. Extensive experiments demonstrate LaViDa-R1's
+    strong performance on a wide range of multimodal tasks, including visual math reasoning, reason-intensive grounding, and
+    image editing.
+  authors:
+  - Shufan Li
+  - Yuchen Zhu
+  - Jiuxiang Gu
+  - Kangning Liu
+  - Zhe Lin
+  - Yongxin Chen
+  - Molei Tao
+  - Aditya Grover
+  - Jason Kuen
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2602.02994
+  title: 'Video-OPD: Efficient Post-Training of Multimodal Large Language Models for Temporal Video Grounding via On-Policy
+    Distillation'
+  date: '2026-02-03'
+  updated: '2026-06-02'
+  url: https://arxiv.org/abs/2602.02994
+  abstract: Reinforcement learning has emerged as a principled post-training paradigm for Temporal Video Grounding (TVG) due
+    to its on-policy optimization, yet existing GRPO-based methods remain fundamentally constrained by sparse reward signals
+    and substantial computational overhead. We propose Video-OPD, an efficient post-training framework for TVG inspired by
+    recent advances in on-policy distillation. Video-OPD optimizes trajectories sampled directly from the current policy,
+    thereby preserving alignment between training and inference distributions, while a frontier teacher supplies dense, token-level
+    supervision via a reverse KL divergence objective. This formulation preserves the on-policy property critical for mitigating
+    distributional shift, while converting sparse, episode-level feedback into fine-grained, step-wise learning signals. Building
+    on Video-OPD, we introduce Teacher-Validated Disagreement Focusing (TVDF), a lightweight training curriculum that iteratively
+    prioritizes trajectories that are both teacher-reliable and maximally informative for the student, thereby improving training
+    efficiency. Empirical results demonstrate that Video-OPD consistently outperforms GRPO while achieving substantially faster
+    convergence and lower computational cost, establishing on-policy distillation as an effective alternative to conventional
+    reinforcement learning for TVG.
+  authors:
+  - Jiaze Li
+  - Hao Yin
+  - Haoran Xu
+  - Boshen Xu
+  - Wenhui Tan
+  - Zewen He
+  - Jianzhong Ju
+  - Zhenbo Luo
+  - Jian Luan
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - distillation
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2602.01326
+  title: 'DreamOn: Diffusion Language Models For Code Infilling Beyond Fixed-size Canvas'
+  date: '2026-02-01'
+  updated: '2026-02-01'
+  url: https://arxiv.org/abs/2602.01326
+  abstract: 'Diffusion Language Models (DLMs) present a compelling alternative to autoregressive models, offering flexible,
+    any-order infilling without specialized prompting design. However, their practical utility is blocked by a critical limitation:
+    the requirement of a fixed-length masked sequence for generation. This constraint severely degrades code infilling performance
+    when the predefined mask size mismatches the ideal completion length. To address this, we propose DreamOn, a novel diffusion
+    framework that enables dynamic, variable-length generation. DreamOn augments the diffusion process with two length control
+    states, allowing the model to autonomously expand or contract the output length based solely on its own predictions. We
+    integrate this mechanism into existing DLMs with minimal modifications to the training objective and no architectural
+    changes. Built upon Dream-Coder-7B and DiffuCoder-7B, DreamOn achieves infilling performance on par with state-of-the-art
+    autoregressive models on HumanEval-Infilling and SantaCoder-FIM and matches oracle performance achieved with ground-truth
+    length. Our work removes a fundamental barrier to the practical deployment of DLMs, significantly advancing their flexibility
+    and applicability for variable-length generation. Our code is available at https://github.com/DreamLM/DreamOn.'
+  authors:
+  - Zirui Wu
+  - Lin Zheng
+  - Zhihui Xie
+  - Jiacheng Ye
+  - Jiahui Gao
+  - Shansan Gong
+  - Yansong Feng
+  - Zhenguo Li
+  - Wei Bi
+  - Guorui Zhou
+  - Lingpeng Kong
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2601.15892
+  title: 'Stable-DiffCoder: Pushing the Frontier of Code Diffusion Large Language Model'
+  date: '2026-01-22'
+  updated: '2026-01-23'
+  url: https://arxiv.org/abs/2601.15892
+  abstract: Diffusion-based language models (DLLMs) offer non-sequential, block-wise generation and richer data reuse compared
+    to autoregressive (AR) models, but existing code DLLMs still lag behind strong AR baselines under comparable budgets.
+    We revisit this setting in a controlled study and introduce Stable-DiffCoder, a block diffusion code model that reuses
+    the Seed-Coder architecture, data, and training pipeline. To enable efficient knowledge learning and stable training,
+    we incorporate a block diffusion continual pretraining (CPT) stage enhanced by a tailored warmup and block-wise clipped
+    noise schedule. Under the same data and architecture, Stable-DiffCoder overall outperforms its AR counterpart on a broad
+    suite of code benchmarks. Moreover, relying only on the CPT and supervised fine-tuning stages, Stable-DiffCoder achieves
+    stronger performance than a wide range of \~8B ARs and DLLMs, demonstrating that diffusion-based training can improve
+    code modeling quality beyond AR training alone. Moreover, diffusion-based any-order modeling improves structured code
+    modeling for editing and reasoning, and through data augmentation, benefits low-resource coding languages.
+  authors:
+  - Chenghao Fan
+  - Wen Heng
+  - Bo Li
+  - Sichen Liu
+  - Yuxuan Song
+  - Jing Su
+  - Xiaoye Qu
+  - Kai Shen
+  - Wei Wei
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2601.14758
+  title: Mechanism Shift During Post-training from Autoregressive to Masked Diffusion Language Models
+  date: '2026-01-21'
+  updated: '2026-08-31'
+  url: https://arxiv.org/abs/2601.14758
+  abstract: Post-training pretrained autoregressive models (ARMs) into masked diffusion models (MDMs) provides an efficient
+    route to diffusion language modeling, but it remains unclear whether the resulting models reuse inherited autoregressive
+    computation or reorganize it for non-autoregressive generation. We compare two 7B ARM-MDM families across four controlled
+    diagnostic tasks and find a task-dependent mechanism shift. On prefix-dominant tasks, MDMs largely preserve inherited
+    high-attribution pathways or exhibit only modest changes in where computation occurs. On globally constrained tasks, the
+    reorganization is substantially stronger, with task-relevant computation shifting toward earlier layers. This depth-wise
+    pattern persists across prompt resampling, circuit budgets, and tested inference budgets, while targeted ablations support
+    the functional importance of the identified structures under the tested intervention protocols. At the component level,
+    diagnostic probes suggest that ARMs rely more strongly on sharply specialized components, whereas MDMs exhibit weaker
+    single-component specialization and more diffuse output-space alignment. Together, these results suggest that diffusion
+    post-training selectively preserves or reorganizes inherited computation according to task structure, rather than uniformly
+    replacing autoregressive mechanisms.
+  authors:
+  - Injin Kong
+  - Hyoungjoon Lee
+  - Yohan Jo
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2601.11214
+  title: 'T$^\star$: Progressive Block Scaling for Masked Diffusion Language Models Through Trajectory Aware Reinforcement
+    Learning'
+  date: '2026-01-16'
+  updated: '2026-06-03'
+  url: https://arxiv.org/abs/2601.11214
+  abstract: We present T$^\star$, a simple TraceRL-based training curriculum for progressive block-size scaling in masked
+    diffusion language models (MDMs). Starting from an AR-initialized small-block MDM, T$^\star$ transitions smoothly to larger
+    blocks, enabling higher-parallelism decoding with minimal performance degradation on math reasoning benchmarks. Moreover,
+    further analysis suggests that T$^\star$ may actually converge to an alternative decoding schedule that achieves comparable
+    performance.
+  authors:
+  - Hanchen Xia
+  - Baoyou Chen
+  - Yutang Ge
+  - Guojiang Zhao
+  - Siyu Zhu
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2601.07568
+  title: 'd3LLM: Ultra-Fast Diffusion LLM using Pseudo-Trajectory Distillation'
+  date: '2026-01-12'
+  updated: '2026-08-06'
+  url: https://arxiv.org/abs/2601.07568
+  abstract: 'Diffusion large language models (dLLMs) offer capabilities beyond those of autoregressive (AR) LLMs, such as
+    parallel decoding and random-order generation. However, realizing these benefits in practice is non-trivial, as dLLMs
+    inherently face an accuracy-parallelism trade-off. Despite increasing interest, existing methods typically focus on only
+    one-side of the coin, targeting either efficiency or accuracy. To address this limitation, we propose d3LLM (Pseudo-Distilled
+    Diffusion Large Language Model), striking a balance between accuracy and parallelism: (i) during training, we introduce
+    pseudo-trajectory distillation to teach the model which tokens can be decoded confidently at early steps, thereby improving
+    parallelism; (ii) during inference, we employ entropy-based multi-block decoding with a KV-cache refresh mechanism to
+    achieve high parallelism while maintaining accuracy. To better evaluate dLLMs, we also introduce AUP (Accuracy Under Parallelism),
+    a new metric that jointly measures accuracy and parallelism. Experiments demonstrate that our d3LLM achieves up to 10$\times$
+    speedup over vanilla LLaDA/Dream, and 5$\times$ speedup over AR models without much accuracy drop. Our code is available
+    at https://github.com/hao-ai-lab/d3LLM.'
+  authors:
+  - Yu-Yang Qian
+  - Junda Su
+  - Lanxiang Hu
+  - Peiyuan Zhang
+  - Zhijie Deng
+  - Peng Zhao
+  - Hao Zhang
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2601.05611
+  title: 'FLARE: Learning Future-Aware Latent Representations from Vision-Language Models for Autonomous Driving'
+  date: '2026-01-09'
+  updated: '2026-03-09'
+  url: https://arxiv.org/abs/2601.05611
+  abstract: While Vision-Language Models (VLMs) offer rich world knowledge for end-to-end autonomous driving, current approaches
+    heavily rely on labor-intensive language annotations (e.g., VQA) to bridge perception and control. This paradigm suffers
+    from a fundamental mismatch between discrete linguistic tokens and continuous driving trajectories, often leading to suboptimal
+    control policies and inefficient utilization of pre-trained knowledge. To address these challenges, we propose FLARE (Future-aware
+    LAtent REpresentation), a novel framework that activates the visual-semantic capabilities of pre-trained VLMs without
+    requiring language supervision. Instead of aligning with text, we introduce a self-supervised future feature prediction
+    objective. This mechanism compels the model to anticipate scene dynamics and ego-motion directly in the latent space,
+    enabling the learning of robust driving representations from large-scale unlabeled trajectory data. Furthermore, we integrate
+    Group Relative Policy Optimization (GRPO) into the planning process to refine decision-making quality. Extensive experiments
+    on the NAVSIM benchmark demonstrate that FLARE achieves state-of-the-art performance, validating the effectiveness of
+    leveraging VLM knowledge via predictive self-supervision rather than explicit language generation.
+  authors:
+  - Chengen Xie
+  - Chonghao Sima
+  - Tianyu Li
+  - Bin Sun
+  - Junjie Wu
+  - Zhihui Hao
+  - Hongyang Li
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2601.02236
+  title: 'CD4LM: Consistency Distillation and aDaptive Decoding for Diffusion Language Models'
+  date: '2026-01-05'
+  updated: '2026-01-05'
+  url: https://arxiv.org/abs/2601.02236
+  abstract: 'Autoregressive large language models achieve strong results on many benchmarks, but decoding remains fundamentally
+    latency-limited by sequential dependence on previously generated tokens. Diffusion language models (DLMs) promise parallel
+    generation but suffer from a fundamental static-to-dynamic misalignment: Training optimizes local transitions under fixed
+    schedules, whereas efficient inference requires adaptive "long-jump" refinements through unseen states. Our goal is to
+    enable highly parallel decoding for DLMs with low number of function evaluations while preserving generation quality.
+    To achieve this, we propose CD4LM, a framework that decouples training from inference via Discrete-Space Consistency Distillation
+    (DSCD) and Confidence-Adaptive Decoding (CAD). Unlike standard objectives, DSCD trains a student to be trajectory-invariant,
+    mapping diverse noisy states directly to the clean distribution. This intrinsic robustness enables CAD to dynamically
+    allocate compute resources based on token confidence, aggressively skipping steps without the quality collapse typical
+    of heuristic acceleration. On GSM8K, CD4LM matches the LLaDA baseline with a 5.18x wall-clock speedup; across code and
+    math benchmarks, it strictly dominates the accuracy-efficiency Pareto frontier, achieving a 3.62x mean speedup while improving
+    average accuracy. Code is available at https://github.com/yihao-liang/CDLM'
+  authors:
+  - Yihao Liang
+  - Ze Wang
+  - Hao Chen
+  - Ximeng Sun
+  - Jialian Wu
+  - Xiaodong Yu
+  - Jiang Liu
+  - Emad Barsoum
+  - Zicheng Liu
+  - Niraj K. Jha
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.24426
+  title: 'Counterfactual VLA: Self-Reflective Vision-Language-Action Model with Adaptive Reasoning'
+  date: '2025-12-30'
+  updated: '2025-12-30'
+  url: https://arxiv.org/abs/2512.24426
+  abstract: 'Recent reasoning-augmented Vision-Language-Action (VLA) models have improved the interpretability of end-to-end
+    autonomous driving by generating intermediate reasoning traces. Yet these models primarily describe what they perceive
+    and intend to do, rarely questioning whether their planned actions are safe or appropriate. This work introduces Counterfactual
+    VLA (CF-VLA), a self-reflective VLA framework that enables the model to reason about and revise its planned actions before
+    execution. CF-VLA first generates time-segmented meta-actions that summarize driving intent, and then performs counterfactual
+    reasoning conditioned on both the meta-actions and the visual context. This step simulates potential outcomes, identifies
+    unsafe behaviors, and outputs corrected meta-actions that guide the final trajectory generation. To efficiently obtain
+    such self-reflective capabilities, we propose a rollout-filter-label pipeline that mines high-value scenes from a base
+    (non-counterfactual) VLA''s rollouts and labels counterfactual reasoning traces for subsequent training rounds. Experiments
+    on large-scale driving datasets show that CF-VLA improves trajectory accuracy by up to 17.6%, enhances safety metrics
+    by 20.5%, and exhibits adaptive thinking: it only enables counterfactual reasoning in challenging scenarios. By transforming
+    reasoning traces from one-shot descriptions to causal self-correction signals, CF-VLA takes a step toward self-reflective
+    autonomous driving agents that learn to think before they act.'
+  authors:
+  - Zhenghao "Mark" Peng
+  - Wenhao Ding
+  - Yurong You
+  - Yuxiao Chen
+  - Wenjie Luo
+  - Thomas Tian
+  - Yulong Cao
+  - Apoorva Sharma
+  - Danfei Xu
+  - Boris Ivanovic
+  - Boyi Li
+  - Bolei Zhou
+  - Yan Wang
+  - Marco Pavone
+  arxiv_categories:
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2512.22737
+  title: 'WeDLM: Reconciling Diffusion Language Models with Standard Causal Attention for Fast Inference'
+  date: '2025-12-28'
+  updated: '2025-12-28'
+  url: https://arxiv.org/abs/2512.22737
+  abstract: Autoregressive (AR) generation is the standard decoding paradigm for Large Language Models (LLMs), but its token-by-token
+    nature limits parallelism at inference time. Diffusion Language Models (DLLMs) offer parallel decoding by recovering multiple
+    masked tokens per step; however, in practice they often fail to translate this parallelism into deployment speed gains
+    over optimized AR engines (e.g., vLLM). A key reason is that many DLLMs rely on bidirectional attention, which breaks
+    standard prefix KV caching and forces repeated contextualization, undermining efficiency. We propose WeDLM, a diffusion
+    decoding framework built entirely on standard causal attention to make parallel generation prefix-cache friendly. The
+    core idea is to let each masked position condition on all currently observed tokens while keeping a strict causal mask,
+    achieved by Topological Reordering that moves observed tokens to the physical prefix while preserving their logical positions.
+    Building on this property, we introduce a streaming decoding procedure that continuously commits confident tokens into
+    a growing left-to-right prefix and maintains a fixed parallel workload, avoiding the stop-and-wait behavior common in
+    block diffusion methods. Experiments show that WeDLM preserves the quality of strong AR backbones while delivering substantial
+    speedups, approaching 3x on challenging reasoning benchmarks and up to 10x in low-entropy generation regimes; critically,
+    our comparisons are against AR baselines served by vLLM under matched deployment settings, demonstrating that diffusion-style
+    decoding can outperform an optimized AR engine in practice.
+  authors:
+  - Aiwei Liu
+  - Minghua He
+  - Shaoxun Zeng
+  - Sijun Zhang
+  - Linhao Zhang
+  - Chuhan Wu
+  - Wei Jia
+  - Yuan Liu
+  - Xiao Zhou
+  - Jie Zhou
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.21446
+  title: 'dUltra: Ultra-Fast Diffusion Language Models via Reinforcement Learning'
+  date: '2025-12-24'
+  updated: '2026-02-06'
+  url: https://arxiv.org/abs/2512.21446
+  abstract: Masked diffusion language models (MDLMs) offer the potential for parallel token generation, but most open-source
+    MDLMs decode fewer than 5 tokens per model forward pass even with sophisticated sampling strategies, limiting their parallel
+    generation potential. Existing acceleration methods either rely on fixed confidence-based heuristics or use distillation-based
+    approaches that finetune MDLMs on trajectories generated by a base model, which can become off-policy during finetuning
+    and restrict performance to the quality of the base model's samples. We propose \texttt{dUltra}, an on-policy reinforcement
+    learning framework based on Group Relative Policy Optimization (GRPO) that learns unmasking strategies for efficient parallel
+    decoding. dUltra introduces an unmasking planner head that predicts per-token unmasking likelihoods under independent
+    Bernoulli distributions. We jointly optimize the base diffusion LLM and the unmasking order planner using reward signals
+    combining verifiable reward, distillation reward, and the number of unmasking steps. Across mathematical reasoning and
+    code generation tasks, dUltra achieves superior accuracy-efficiency trade-offs compared to state-of-the-art heuristic
+    (Fast-dLLM) and distillation baselines (d3LLM, dParallel), demonstrating that learned unmasking trajectories through on-policy
+    RL enable better exploitation of parallel generation in MDLMs. Code and checkpoints are released at https://github.com/chinsengi/dUltra-os.
+  authors:
+  - Shirui Chen
+  - Jiantao Jiao
+  - Lillian J. Ratliff
+  - Banghua Zhu
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.18211
+  title: 'LLaViDA: A Large Language Vision Driving Assistant for Explicit Reasoning and Enhanced Trajectory Planning'
+  date: '2025-12-20'
+  updated: '2025-12-20'
+  url: https://arxiv.org/abs/2512.18211
+  abstract: Trajectory planning is a fundamental yet challenging component of autonomous driving. End-to-end planners frequently
+    falter under adverse weather, unpredictable human behavior, or complex road layouts, primarily because they lack strong
+    generalization or few-shot capabilities beyond their training data. We propose LLaViDA, a Large Language Vision Driving
+    Assistant that leverages a Vision-Language Model (VLM) for object motion prediction, semantic grounding, and chain-of-thought
+    reasoning for trajectory planning in autonomous driving. A two-stage training pipeline--supervised fine-tuning followed
+    by Trajectory Preference Optimization (TPO)--enhances scene understanding and trajectory planning by injecting regression-based
+    supervision, produces a powerful "VLM Trajectory Planner for Autonomous Driving." On the NuScenes benchmark, LLaViDA surpasses
+    state-of-the-art end-to-end and other recent VLM/LLM-based baselines in open-loop trajectory planning task, achieving
+    an average L2 trajectory error of 0.31 m and a collision rate of 0.10% on the NuScenes test set. The code for this paper
+    is available at GitHub.
+  authors:
+  - Yudong Liu
+  - Spencer Hallyburton
+  - Jiwoo Kim
+  - Yueqian Lin
+  - Yiming Li
+  - Qinsi Wang
+  - Hui Ye
+  - Jingwei Sun
+  - Miroslav Pajic
+  - Yiran Chen
+  - Hai Li
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2512.16760
+  title: 'Vision-Language-Action Models for Autonomous Driving: Past, Present, and Future'
+  date: '2025-12-18'
+  updated: '2026-01-04'
+  url: https://arxiv.org/abs/2512.16760
+  abstract: 'Autonomous driving has long relied on modular "Perception-Decision-Action" pipelines, where hand-crafted interfaces
+    and rule-based components often break down in complex or long-tailed scenarios. Their cascaded design further propagates
+    perception errors, degrading downstream planning and control. Vision-Action (VA) models address some limitations by learning
+    direct mappings from visual inputs to actions, but they remain opaque, sensitive to distribution shifts, and lack structured
+    reasoning or instruction-following capabilities. Recent progress in Large Language Models (LLMs) and multimodal learning
+    has motivated the emergence of Vision-Language-Action (VLA) frameworks, which integrate perception with language-grounded
+    decision making. By unifying visual understanding, linguistic reasoning, and actionable outputs, VLAs offer a pathway
+    toward more interpretable, generalizable, and human-aligned driving policies. This work provides a structured characterization
+    of the emerging VLA landscape for autonomous driving. We trace the evolution from early VA approaches to modern VLA frameworks
+    and organize existing methods into two principal paradigms: End-to-End VLA, which integrates perception, reasoning, and
+    planning within a single model, and Dual-System VLA, which separates slow deliberation (via VLMs) from fast, safety-critical
+    execution (via planners). Within these paradigms, we further distinguish subclasses such as textual vs. numerical action
+    generators and explicit vs. implicit guidance mechanisms. We also summarize representative datasets and benchmarks for
+    evaluating VLA-based driving systems and highlight key challenges and open directions, including robustness, interpretability,
+    and instruction fidelity. Overall, this work aims to establish a coherent foundation f'
+  authors:
+  - Tianshuai Hu
+  - Xiaolu Liu
+  - Song Wang
+  - Yiyao Zhu
+  - Ao Liang
+  - Lingdong Kong
+  - Guoyang Zhao
+  - Zeying Gong
+  - Jun Cen
+  - Zhiyu Huang
+  - Xiaoshuai Hao
+  - Linfeng Li
+  - Hang Song
+  - Xiangtai Li
+  - Jun Ma
+  - Shaojie Shen
+  - Jianke Zhu
+  - Dacheng Tao
+  - Ziwei Liu
+  - Junwei Liang
+  arxiv_categories:
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2512.15745
+  title: 'LLaDA2.0: Scaling Up Diffusion Language Models to 100B'
+  date: '2025-12-10'
+  updated: '2025-12-24'
+  url: https://arxiv.org/abs/2512.15745
+  abstract: 'This paper presents LLaDA2.0 -- a tuple of discrete diffusion large language models (dLLM) scaling up to 100B
+    total parameters through systematic conversion from auto-regressive (AR) models -- establishing a new paradigm for frontier-scale
+    deployment. Instead of costly training from scratch, LLaDA2.0 upholds knowledge inheritance, progressive adaption and
+    efficiency-aware design principle, and seamless converts a pre-trained AR model into dLLM with a novel 3-phase block-level
+    WSD based training scheme: progressive increasing block-size in block diffusion (warm-up), large-scale full-sequence diffusion
+    (stable) and reverting back to compact-size block diffusion (decay). Along with post-training alignment with SFT and DPO,
+    we obtain LLaDA2.0-mini (16B) and LLaDA2.0-flash (100B), two instruction-tuned Mixture-of-Experts (MoE) variants optimized
+    for practical deployment. By preserving the advantages of parallel decoding, these models deliver superior performance
+    and efficiency at the frontier scale. Both models were open-sourced.'
+  authors:
+  - Tiwei Bie
+  - Maosong Cao
+  - Kun Chen
+  - Lun Du
+  - Mingliang Gong
+  - Zhuochen Gong
+  - Yanmei Gu
+  - Jiaqi Hu
+  - Zenan Huang
+  - Zhenzhong Lan
+  - Chengxi Li
+  - Chongxuan Li
+  - Jianguo Li
+  - Zehuan Li
+  - Huabin Liu
+  - Lin Liu
+  - Guoshan Lu
+  - Xiaocheng Lu
+  - Yuxin Ma
+  - Jianfeng Tan
+  - Lanning Wei
+  - Ji-Rong Wen
+  - Yipeng Xing
+  - Xiaolu Zhang
+  - Junbo Zhao
+  - Da Zheng
+  - Jun Zhou
+  - Junlin Zhou
+  - Zhanchao Zhou
+  - Liwang Zhu
+  - Yihong Zhuang
+  arxiv_categories:
+  - cs.LG
+  - cs.AI
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.15713
+  title: 'DiffusionVL: Translating Any Autoregressive Models into Diffusion Vision Language Models'
+  date: '2025-12-17'
+  updated: '2026-03-31'
+  url: https://arxiv.org/abs/2512.15713
+  abstract: 'Diffusion-based decoding has recently emerged as an appealing alternative to autoregressive (AR) generation,
+    offering the potential to update multiple tokens in parallel and reduce latency. However, diffusion vision language models
+    (dVLMs) still lag significantly behind mainstream autoregressive vision language models. This is due to the scarcity and
+    weaker performance of base diffusion language models (dLLMs) compared with their autoregressive counterparts. This raises
+    a natural question: Can we build high-performing dVLMs directly from existing powerful AR models, without relying on dLLMs?
+    We propose DiffusionVL, a family of dVLMs obtained by translating pretrained AR models into the diffusion paradigm via
+    an efficient diffusion finetuning procedure that changes the training objective and decoding process while keeping the
+    backbone architecture intact. Through an efficient diffusion finetuning strategy, we successfully adapt AR pretrained
+    models into the diffusion paradigm. This approach yields two key observations: (1) The paradigm shift from AR-based multimodal
+    models to diffusion is remarkably effective. (2) Direct conversion of an AR language model to a dVLM is also feasible,
+    achieving performance comparable to that of the same AR model finetuned with standard autoregressive visual instruction
+    tuning. To enable practical open-ended generation, we further integrate block decoding, which supports arbitrary-length
+    outputs and KV-cache reuse for faster inference. Our experiments demonstrate that despite training with less than 5% of
+    the data required by prior methods, DiffusionVL achieves a comprehensive performance improvement, with a 34.4% gain on
+    the MMMU-Pro (vision) benchmark and 37.5% gain on the MME (Cog.) benchmark, alongside a 2x inference speedup. The model'
+  authors:
+  - Lunbin Zeng
+  - Jingfeng Yao
+  - Bencheng Liao
+  - Hongyuan Tao
+  - Wenyu Liu
+  - Xinggang Wang
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.15596
+  title: Corrective Diffusion Language Models
+  date: '2025-12-17'
+  updated: '2026-01-29'
+  url: https://arxiv.org/abs/2512.15596
+  abstract: While Diffusion Language Models (DLMs) are theoretically well-suited for iterative refinement due to their non-causal
+    structure, they often fail to reliably revise incorrect tokens in practice. The key challenge lies in the model's inability
+    to distinguish between correct and erroneous tokens in a visible sequence. Standard masked diffusion language model (MDLM)
+    training is restricted to the objective of unmasking, undermining the effectiveness of refinement guided by confidence.
+    Based on this observation, we study corrective behavior in DLMs, defined as the ability to assign lower confidence to
+    incorrect tokens and iteratively refine them while preserving correct content. We show that this capability is not induced
+    by conventional masked diffusion objectives and propose a post-training principle oriented by correction that explicitly
+    supervises visible incorrect tokens, enabling discriminative confidence and targeted refinement. To evaluate corrective
+    behavior, we introduce the Code Revision Benchmark, a controllable and executable benchmark for assessing error localization
+    and in-place correction. Experiments on code revision tasks and parallel decoding scenarios demonstrate that models trained
+    with our approach substantially outperform standard MDLMs, with gains that are most pronounced when parallel decoding
+    introduces substantial uncertainty and iterative refinement becomes essential. Our code is publicly available at https://github.com/zhangshuibai/CDLM.
+  authors:
+  - Shuibai Zhang
+  - Fred Zhangzhi Peng
+  - Yiheng Zhang
+  - Jin Pan
+  - Grigorios G. Chrysos
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.14068
+  title: 'SDAR-VL: Stable and Efficient Block-wise Diffusion for Vision-Language Understanding'
+  date: '2025-12-16'
+  updated: '2025-12-16'
+  url: https://arxiv.org/abs/2512.14068
+  abstract: 'Block-wise discrete diffusion offers an attractive balance between parallel generation and causal dependency
+    modeling, making it a promising backbone for vision-language modeling. However, its practical adoption has been limited
+    by high training cost, slow convergence, and instability, which have so far kept it behind strong autoregressive (AR)
+    baselines. We present \textbf{SDAR-VL}, the first systematic application of block-wise discrete diffusion to large-scale
+    vision-language understanding (VLU), together with an \emph{integrated framework for efficient and stable training}. This
+    framework unifies three components: (1) \textbf{Asynchronous Block-wise Noise Scheduling} to diversify supervision within
+    each batch; (2) \textbf{Effective Mask Ratio Scaling} for unbiased loss normalization under stochastic masking; and (3)
+    a \textbf{Progressive Beta Noise Curriculum} that increases effective mask coverage while preserving corruption diversity.
+    Experiments on 21 single-image, multi-image, and video benchmarks show that SDAR-VL consistently improves \emph{training
+    efficiency}, \emph{convergence stability}, and \emph{task performance} over conventional block diffusion. On this evaluation
+    suite, SDAR-VL sets a new state of the art among diffusion-based vision-language models and, under matched settings, matches
+    or surpasses strong AR baselines such as LLaVA-OneVision as well as the global diffusion baseline LLaDA-V, establishing
+    block-wise diffusion as a practical backbone for VLU.'
+  authors:
+  - Shuang Cheng
+  - Yuhua Jiang
+  - Zineng Zhou
+  - Dawei Liu
+  - Wang Tao
+  - Linfeng Zhang
+  - Biqing Qi
+  - Bowen Zhou
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.14067
+  title: 'Efficient-DLM: From Autoregressive to Diffusion Language Models, and Beyond in Speed'
+  date: '2025-12-16'
+  updated: '2026-04-29'
+  url: https://arxiv.org/abs/2512.14067
+  abstract: Diffusion language models (dLMs) have emerged as a promising paradigm that enables parallel, non-autoregressive
+    generation, but their learning efficiency lags behind that of autoregressive (AR) language models when trained from scratch.
+    To this end, we study AR-to-dLM conversion to transform pretrained AR models into efficient dLMs that excel in speed while
+    preserving AR models' task accuracy. We achieve this by identifying limitations in the attention patterns and objectives
+    of existing AR-to-dLM methods and then proposing principles and methodologies for more effective AR-to-dLM conversion.
+    Specifically, we first systematically compare different attention patterns and find that maintaining pretrained AR weight
+    distributions is critical for effective AR-to-dLM conversion. As such, we introduce a continuous pretraining scheme with
+    a block-wise attention pattern, which remains causal across blocks while enabling bidirectional modeling within each block.
+    We find that this approach can better preserve pretrained AR models' weight distributions than fully bidirectional modeling,
+    in addition to its known benefit of enabling KV caching, and leads to a win-win in accuracy and efficiency. Second, to
+    mitigate the training-test gap in mask token distributions (uniform vs. highly left-to-right), we propose a position-dependent
+    token masking strategy that assigns higher masking probabilities to later tokens during training to better mimic test-time
+    behavior. Leveraging this framework, we conduct extensive studies of dLMs' attention patterns, training dynamics, and
+    other design choices, providing actionable insights into scalable AR-to-dLM conversion. These studies lead to the Efficient-DLM
+    family, which outperforms state-of-the-art AR models and dLMs, e.g., our Efficient-DLM 8B ach
+  authors:
+  - Yonggan Fu
+  - Lexington Whalen
+  - Zhifan Ye
+  - Xin Dong
+  - Shizhe Diao
+  - Jingyu Liu
+  - Chengyue Wu
+  - Hao Zhang
+  - Enze Xie
+  - Song Han
+  - Maksim Khadkevich
+  - Jan Kautz
+  - Yingyan Celine Lin
+  - Pavlo Molchanov
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.14008
+  title: 'Sparse-LaViDa: Sparse Multimodal Discrete Diffusion Language Models'
+  date: '2025-12-16'
+  updated: '2026-07-15'
+  url: https://arxiv.org/abs/2512.14008
+  abstract: Masked Discrete Diffusion Models (MDMs) have achieved strong performance across a wide range of multimodal tasks,
+    including image understanding, generation, and editing. However, their inference speed remains suboptimal due to the need
+    to repeatedly process redundant masked tokens at every sampling step. In this work, we propose Sparse-LaViDa, a novel
+    modeling framework that dynamically truncates unnecessary masked tokens at each inference step to accelerate MDM sampling.
+    To preserve generation quality, we introduce specialized register tokens that serve as compact representations for the
+    truncated tokens. Furthermore, to ensure consistency between training and inference, we design a specialized attention
+    mask that faithfully matches the truncated sampling procedure during training. Built upon the state-of-the-art unified
+    MDM LaViDa-O, Sparse-LaViDa achieves up to a 2x speedup across diverse tasks including text-to-image generation, image
+    editing, and mathematical reasoning, while maintaining generation quality.
+  authors:
+  - Shufan Li
+  - Jiuxiang Gu
+  - Kangning Liu
+  - Zhe Lin
+  - Zijun Wei
+  - Aditya Grover
+  - Jason Kuen
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.09675
+  title: 'd-TreeRPO: Towards More Reliable Policy Optimization for Diffusion Language Models'
+  date: '2025-12-10'
+  updated: '2026-05-13'
+  url: https://arxiv.org/abs/2512.09675
+  abstract: 'Reinforcement learning (RL) is pivotal for enhancing the reasoning capabilities of diffusion large language models
+    (dLLMs). However, existing dLLM policy optimization methods suffer from two critical reliability bottlenecks: (1) reward
+    sparsity, arising from coarse or unverifiable signals that impede accurate advantage calculation; and (2) their probability
+    estimates do not account for the gap to the unbiased expectation over all decoding orders, which are intractable to compute.
+    To mitigate these issues, we propose d-TreeRPO, a reliable RL framework for dLLMs that leverages tree-structured rollouts
+    and bottom-up advantage computation based on verifiable outcome rewards to provide fine-grained and verifiable step-wise
+    reward signals. Furthermore, we provide a theoretical proof demonstrating that increasing prediction confidence effectively
+    minimizes the gap between unbiased expected prediction probabilities and its single-step forward pass estimate. Guided
+    by this analysis, we introduce a time-scheduled self-distillation loss during training that enhances prediction confidence
+    in later training stages, thereby enabling more accurate probability estimation and better performance. Experiments demonstrate
+    that d-TreeRPO outperforms existing baselines and achieves significant improvements across multiple reasoning benchmarks.
+    Specifically, it achieves +86.2% on Sudoku, +51.6% on Countdown, +4.5% on GSM8K, and +5.3% on Math500 compared to the
+    base model.'
+  authors:
+  - Leyi Pan
+  - Shuchang Tao
+  - Yunpeng Zhai
+  - Zheyu Fu
+  - Liancheng Fang
+  - Minghua He
+  - Lingzhe Zhang
+  - Zhaoyang Liu
+  - Bolin Ding
+  - Aiwei Liu
+  - Lijie Wen
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.09106
+  title: Learning Unmasking Policies for Diffusion Language Models
+  date: '2025-12-09'
+  updated: '2026-06-01'
+  url: https://arxiv.org/abs/2512.09106
+  abstract: 'Diffusion (Large) Language Models (dLLMs) now match the downstream performance of their autoregressive counterparts
+    on many tasks, while holding the promise of being more efficient during inference. One critical design aspect of dLLMs
+    is the sampling procedure that selects which tokens to unmask at each diffusion step. Indeed, recent work has found that
+    heuristic strategies such as confidence thresholding improve both sample quality and token throughput compared to random
+    unmasking. However, such heuristics have downsides: they require manual tuning, and we observe that their performance
+    degrades with larger block sizes. In this work, we instead propose to train sampling procedures using reinforcement learning.
+    Specifically, we formalize masked diffusion sampling as a Markov decision process in which the dLLM serves as the environment,
+    and propose a lightweight policy based on a single-layer transformer that maps dLLM token confidences to unmasking decisions.
+    Our experiments show that these trained policies match the performance of state-of-the-art heuristics when combined with
+    semi-autoregressive (block) generation, while outperforming them in the full-diffusion setting.'
+  authors:
+  - Metod Jazbec
+  - Theo X. Olausson
+  - Louis Béthune
+  - Pierre Ablin
+  - Michael Kirchhof
+  - João Monteiro
+  - Victor Turrisi
+  - Jason Ramapuram
+  - Marco Cuturi
+  arxiv_categories:
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.07745
+  title: 'DiffusionDriveV2: Reinforcement Learning-Constrained Truncated Diffusion Modeling in End-to-End Autonomous Driving'
+  date: '2025-12-08'
+  updated: '2025-12-08'
+  url: https://arxiv.org/abs/2512.07745
+  abstract: Generative diffusion models for end-to-end autonomous driving often suffer from mode collapse, tending to generate
+    conservative and homogeneous behaviors. While DiffusionDrive employs predefined anchors representing different driving
+    intentions to partition the action space and generate diverse trajectories, its reliance on imitation learning lacks sufficient
+    constraints, resulting in a dilemma between diversity and consistent high quality. In this work, we propose DiffusionDriveV2,
+    which leverages reinforcement learning to both constrain low-quality modes and explore for superior trajectories. This
+    significantly enhances the overall output quality while preserving the inherent multimodality of its core Gaussian Mixture
+    Model. First, we use scale-adaptive multiplicative noise, ideal for trajectory planning, to promote broad exploration.
+    Second, we employ intra-anchor GRPO to manage advantage estimation among samples generated from a single anchor, and inter-anchor
+    truncated GRPO to incorporate a global perspective across different anchors, preventing improper advantage comparisons
+    between distinct intentions (e.g., turning vs. going straight), which can lead to further mode collapse. DiffusionDriveV2
+    achieves 91.2 PDMS on the NAVSIM v1 dataset and 85.5 EPDMS on the NAVSIM v2 dataset in closed-loop evaluation with an
+    aligned ResNet-34 backbone, setting a new record. Further experiments validate that our approach resolves the dilemma
+    between diversity and consistent high quality for truncated diffusion models, achieving the best trade-off. Code and model
+    will be available at https://github.com/hustvl/DiffusionDriveV2
+  authors:
+  - Jialv Zou
+  - Shaoyu Chen
+  - Bencheng Liao
+  - Zhiyu Zheng
+  - Yuehao Song
+  - Lefei Zhang
+  - Qian Zhang
+  - Wenyu Liu
+  - Xinggang Wang
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - generative-media
+  - reinforcement-learning
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2512.06776
+  title: 'From Next-Token to Next-Block: A Principled Adaptation Path for Diffusion LLMs'
+  date: '2025-12-07'
+  updated: '2026-01-30'
+  url: https://arxiv.org/abs/2512.06776
+  abstract: 'Diffusion Language Models (DLMs) enable fast generation, yet training large DLMs from scratch is costly. As a
+    practical shortcut, adapting off-the-shelf Auto-Regressive (AR) model weights into a DLM could quickly equip the DLM with
+    strong long-context generation capabilies. Prior "adaptation" attempts either modify logits or randomly grow attention
+    masks to Full-Sequence diffusion, or simply transplant AR weights into a Block-Diffusion recipe, leaving two key questions
+    unaddressed: where is the final destination of adaptation, and how to adapt better? For manifold benefits, we reframe
+    the whole AR-to-DLM adaptation under the Block-Diffusion paradigm, transitioning from block size 1 to the final Block-Diffusion
+    state. Concretely, the principled pathway of adaptation is designed as follows: we keep a context-causal path where causal
+    attention is kept in the prefix, an efficient parallel adaptation procedure where an AR guidance is maintained, and gradual
+    increment of the generation block size for a smoother transition. Built on these components, the adaptation is proved
+    competitive on various models at different scales. With better adaptation, we propose NBDiff-7B that could inherit the
+    long-context modeling and reasoning capabilities, and achieve state-of-the-art performance among the 7B-class DLMs. Codes:
+    https://github.com/YuchuanTian/NBDiff.'
+  authors:
+  - Yuchuan Tian
+  - Yuchen Liang
+  - Shuo Zhang
+  - Yingte Shu
+  - Guangwen Yang
+  - Wei He
+  - Sibo Fang
+  - Tianyu Guo
+  - Kai Han
+  - Chao Xu
+  - Hanting Chen
+  - Xinghao Chen
+  - Yunhe Wang
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - generative-media
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.03759
+  title: Principled RL for Diffusion LLMs Emerges from a Sequence-Level Perspective
+  date: '2025-12-03'
+  updated: '2025-12-03'
+  url: https://arxiv.org/abs/2512.03759
+  abstract: 'Reinforcement Learning (RL) has proven highly effective for autoregressive language models, but adapting these
+    methods to diffusion large language models (dLLMs) presents fundamental challenges. The core difficulty lies in likelihood
+    approximation: while autoregressive models naturally provide token-level conditional probabilities essential for token-level
+    RL objectives (e.g., GRPO), dLLMs generate sequences through iterative non-autoregressive denoising steps that lack this
+    factorization. To address this fundamental mismatch, we propose ELBO-based Sequence-level Policy Optimization (ESPO),
+    a principled RL framework that treats entire sequence generation as a single action and uses the ELBO as a tractable sequence-level
+    likelihood proxy. Our method incorporates per-token normalization of importance ratios and robust KL-divergence estimation
+    to ensure stable large-scale training. Extensive experiments on mathematical reasoning, coding, and planning tasks demonstrate
+    that ESPO significantly outperforms token-level baselines, achieving dramatic improvements of 20-40 points on the Countdown
+    task, while maintaining consistent gains on math and coding benchmarks. Our approach establishes sequence-level optimization
+    as a principled and empirically effective paradigm for RL in dLLMs. Our code is available at https://github.com/ML-GSAI/ESPO.'
+  authors:
+  - Jingyang Ou
+  - Jiaqi Han
+  - Minkai Xu
+  - Shaoxuan Xu
+  - Jianwen Xie
+  - Stefano Ermon
+  - Yi Wu
+  - Chongxuan Li
+  arxiv_categories:
+  - cs.CL
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2512.03667
+  title: 'Colon-X: Advancing Intelligent Colonoscopy toward Clinical Reasoning'
+  date: '2025-12-03'
+  updated: '2026-03-14'
+  url: https://arxiv.org/abs/2512.03667
+  abstract: 'In this study, we present Colon-X, an open initiative aimed at advancing multimodal intelligence in colonoscopy.
+    We begin by constructing ColonVQA, the most comprehensive multimodal dataset ever built for colonoscopy, featuring over
+    1.1M+ visual question answering entries across 76 clinical findings and 18 multimodal tasks. Beyond serving as a community-wide
+    data foundation, we further investigate a critical yet underexplored transition in colonoscopy - evolving from multimodal
+    understanding to clinical reasoning: (a) To capture the current landscape of multimodal understanding behaviors, we systematically
+    assess the generalizability of 22 multimodal large language models and examine their reliability under human-induced perturbations.
+    The results reveal that clinical outputs from leading MLLMs remain far from robust and trustworthy. (b) To narrow this
+    gap, we further explore reasoning-centric intelligence tailored for colonoscopy. Specifically, we curate ColonReason,
+    a clinically grounded reasoning dataset annotated through a multi-agent debating pipeline, and develop ColonR1, the first
+    R1-styled model that mitigates reward information collapse through task-adaptive rewards and gradient-stable policy optimization.
+    Under data-scarce conditions, our ColonR1 achieves 56.61% overall accuracy, outperforming supervised fine-tuning by 25.22%,
+    and sets a new reasoning-enabled baseline for multimodal colonoscopy analysis. All data and model resources are publicly
+    available at https://github.com/ai4colonoscopy/Colon-X.'
+  authors:
+  - Ge-Peng Ji
+  - Jingyi Liu
+  - Deng-Ping Fan
+  - Huazhu Fu
+  - Nick Barnes
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:mbzuai-llm-post-training
+  direction_hints:
+  - multimodal
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:mbzuai-llm-post-training
+- id: arxiv:2511.21631
+  title: Qwen3-VL Technical Report
+  date: '2025-11-26'
+  updated: '2025-11-27'
+  url: https://arxiv.org/abs/2511.21631
+  abstract: 'We introduce Qwen3-VL, the most capable vision-language model in the Qwen series to date, achieving superior
+    performance across a broad range of multimodal benchmarks. It natively supports interleaved contexts of up to 256K tokens,
+    seamlessly integrating text, images, and video. The model family includes both dense (2B/4B/8B/32B) and mixture-of-experts
+    (30B-A3B/235B-A22B) variants to accommodate diverse latency-quality trade-offs. Qwen3-VL delivers three core pillars:
+    (i) markedly stronger pure-text understanding, surpassing comparable text-only backbones in several cases; (ii) robust
+    long-context comprehension with a native 256K-token window for both text and interleaved multimodal inputs, enabling faithful
+    retention, retrieval, and cross-referencing across long documents and videos; and (iii) advanced multimodal reasoning
+    across single-image, multi-image, and video tasks, demonstrating leading performance on comprehensive evaluations such
+    as MMMU and visual-math benchmarks (e.g., MathVista and MathVision). Architecturally, we introduce three key upgrades:
+    (i) an enhanced interleaved-MRoPE for stronger spatial-temporal modeling across images and video; (ii) DeepStack integration,
+    which effectively leverages multi-level ViT features to tighten vision-language alignment; and (iii) text-based time alignment
+    for video, evolving from T-RoPE to explicit textual timestamp alignment for more precise temporal grounding. Under comparable
+    token budgets and latency constraints, Qwen3-VL achieves superior performance in both dense and Mixture-of-Experts (MoE)
+    architectures. We envision Qwen3-VL serving as a foundational engine for image-grounded reasoning, agentic decision-making,
+    and multimodal code intelligence in real-world workflows.'
+  authors:
+  - Shuai Bai
+  - Yuxuan Cai
+  - Ruizhe Chen
+  - Keqin Chen
+  - Xionghui Chen
+  - Zesen Cheng
+  - Lianghao Deng
+  - Wei Ding
+  - Chang Gao
+  - Chunjiang Ge
+  - Wenbin Ge
+  - Zhifang Guo
+  - Qidong Huang
+  - Jie Huang
+  - Fei Huang
+  - Binyuan Hui
+  - Shutong Jiang
+  - Zhaohai Li
+  - Mingsheng Li
+  - Mei Li
+  - Kaixin Li
+  - Zicheng Lin
+  - Junyang Lin
+  - Xuejing Liu
+  - Jiawei Liu
+  - Chenglong Liu
+  - Yang Liu
+  - Dayiheng Liu
+  - Shixuan Liu
+  - Dunjie Lu
+  - Ruilin Luo
+  - Chenxu Lv
+  - Rui Men
+  - Lingchen Meng
+  - Xuancheng Ren
+  - Xingzhang Ren
+  - Sibo Song
+  - Yuchong Sun
+  - Jun Tang
+  - Jianhong Tu
+  - Jianqiang Wan
+  - Peng Wang
+  - Pengfei Wang
+  - Qiuyue Wang
+  - Yuxuan Wang
+  - Tianbao Xie
+  - Yiheng Xu
+  - Haiyang Xu
+  - Jin Xu
+  - Zhibo Yang
+  - Mingkun Yang
+  - Jianxin Yang
+  - An Yang
+  - Bowen Yu
+  - Fei Zhang
+  - Hang Zhang
+  - Xi Zhang
+  - Bo Zheng
+  - Humen Zhong
+  - Jingren Zhou
+  - Fan Zhou
+  - Jing Zhou
+  - Yuanzhi Zhu
+  - Ke Zhu
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:multimodal-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:multimodal-post-training
+- id: arxiv:2511.19912
+  title: 'Reasoning-VLA: A Fast and General Vision-Language-Action Reasoning Model for Autonomous Driving'
+  date: '2025-11-25'
+  updated: '2025-11-25'
+  url: https://arxiv.org/abs/2511.19912
+  abstract: Vision-Language-Action (VLA) models have recently shown strong decision-making capabilities in autonomous driving.
+    However, existing VLAs often struggle with achieving efficient inference and generalizing to novel autonomous vehicle
+    configurations and driving scenarios. In this paper, we propose Reasoning-VLA, a general and fast action-generation VLA
+    framework. The proposed model employs a set of learnable action queries, initialized via Gaussian sampling from ground-truth
+    trajectories within the training corpus. These learnable queries interact with reasoning-enhanced vision-language features
+    to generate continuous action trajectories in parallel. To promote robust generalization, we consolidate eight publicly
+    available autonomous driving datasets into a standardized, Chain-of-Thought reasoning-based, and easy-to-use data format
+    for model training. Leveraging both supervised learning and reinforcement learning fine-tuning, extensive empirical evaluations
+    across multiple benchmarks demonstrate that Reasoning-VLA achieves state-of-the-art performance, superior generalization
+    capability, and the excellent inference speed reported to date.
+  authors:
+  - Dapeng Zhang
+  - Zhenlong Yuan
+  - Zhangquan Chen
+  - Chih-Ting Liao
+  - Yinda Chen
+  - Fei Shen
+  - Qingguo Zhou
+  - Tat-Seng Chua
+  arxiv_categories:
+  - cs.CV
+  - cs.RO
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - multimodal
+  - reasoning-self-improvement
+  - supervised-adaptation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2511.19269
+  title: 'CDLM: Consistency Diffusion Language Models For Faster Sampling'
+  date: '2025-11-24'
+  updated: '2026-02-20'
+  url: https://arxiv.org/abs/2511.19269
+  abstract: Diffusion Language Models (DLMs) offer a promising parallel generation paradigm but suffer from slow inference
+    due to numerous refinement steps and the inability to use standard KV caching. We introduce CDLM (Consistency Diffusion
+    Language Models), a training-based acceleration method that simultaneously tackles both bottlenecks. CDLM integrates consistency
+    modeling to drastically reduce the number of required sampling steps by enabling multi-token finalization. Furthermore,
+    we enforce a block-wise causal attention mask during fine-tuning, making the model fully compatible with KV caching. Experiments
+    show CDLM achieves 3.6x-14.5x lower latency while maintaining competitive accuracy on math and coding tasks. The full
+    training and evaluation code is available at https://github.com/SqueezeAILab/CDLM.
+  authors:
+  - Minseo Kim
+  - Chenfeng Xu
+  - Coleman Hooper
+  - Harman Singh
+  - Ben Athiwaratkun
+  - Ce Zhang
+  - Kurt Keutzer
+  - Amir Gholami
+  arxiv_categories:
+  - cs.LG
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - distillation
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2511.09611
+  title: 'MMaDA-Parallel: Multimodal Large Diffusion Language Models for Thinking-Aware Editing and Generation'
+  date: '2025-11-12'
+  updated: '2025-11-18'
+  url: https://arxiv.org/abs/2511.09611
+  abstract: While thinking-aware generation aims to improve performance on complex tasks, we identify a critical failure mode
+    where existing sequential, autoregressive approaches can paradoxically degrade performance due to error propagation. To
+    systematically analyze this issue, we propose ParaBench, a new benchmark designed to evaluate both text and image output
+    modalities. Our analysis using ParaBench reveals that this performance degradation is strongly correlated with poor alignment
+    between the generated reasoning and the final image. To resolve this, we propose a parallel multimodal diffusion framework,
+    MMaDA-Parallel, that enables continuous, bidirectional interaction between text and images throughout the entire denoising
+    trajectory. MMaDA-Parallel is trained with supervised finetuning and then further optimized by Parallel Reinforcement
+    Learning (ParaRL), a novel strategy that applies semantic rewards along the trajectory to enforce cross-modal consistency.
+    Experiments validate that our model significantly improves cross-modal alignment and semantic consistency, achieving a
+    6.9\% improvement in Output Alignment on ParaBench compared to the state-of-the-art model, Bagel, establishing a more
+    robust paradigm for thinking-aware image synthesis. Our code is open-sourced at https://github.com/tyfeld/MMaDA-Parallel
+  authors:
+  - Ye Tian
+  - Ling Yang
+  - Jiongfan Yang
+  - Anran Wang
+  - Yu Tian
+  - Jiani Zheng
+  - Haochen Wang
+  - Zhiyang Teng
+  - Zhuochen Wang
+  - Yinjie Wang
+  - Yunhai Tong
+  - Mengdi Wang
+  - Xiangtai Li
+  arxiv_categories:
+  - cs.CV
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2511.00088
+  title: 'Alpamayo-R1: Bridging Reasoning and Action Prediction for Generalizable Autonomous Driving in the Long Tail'
+  date: '2025-10-30'
+  updated: '2026-01-07'
+  url: https://arxiv.org/abs/2511.00088
+  abstract: 'End-to-end architectures trained via imitation learning have advanced autonomous driving by scaling model size
+    and data, yet performance remains brittle in safety-critical long-tail scenarios where supervision is sparse and causal
+    understanding is limited. We introduce Alpamayo-R1 (AR1), a vision-language-action model (VLA) that integrates Chain of
+    Causation reasoning with trajectory planning for complex driving scenarios. Our approach features three key innovations:
+    (1) the Chain of Causation (CoC) dataset, built through a hybrid auto-labeling and human-in-the-loop pipeline producing
+    decision-grounded, causally linked reasoning traces aligned with driving behaviors; (2) a modular VLA architecture combining
+    Cosmos-Reason, a vision-language model pre-trained for Physical AI, with a diffusion-based trajectory decoder that generates
+    dynamically feasible trajectories in real time; (3) a multi-stage training strategy using supervised fine-tuning to elicit
+    reasoning and reinforcement learning (RL) to enforce reasoning-action consistency and optimize reasoning quality. AR1
+    achieves up to a 12% improvement in planning accuracy on challenging cases compared to a trajectory-only baseline, with
+    a 35% reduction in close encounter rate in closed-loop simulation. RL post-training improves reasoning quality by 45%
+    and reasoning-action consistency by 37%. Model scaling from 0.5B to 7B parameters shows consistent improvements. On-vehicle
+    road tests confirm real-time performance (99 ms latency) and successful urban deployment. By bridging interpretable reasoning
+    with precise control, AR1 demonstrates a practical path towards Level 4 autonomous driving. Model weights are available
+    at https://huggingface.co/nvidia/Alpamayo-R1-10B with inference code at https://github.com/NVlabs/alpamayo.'
+  authors:
+  - ' NVIDIA'
+  - ' :'
+  - Yan Wang
+  - Wenjie Luo
+  - Junjie Bai
+  - Yulong Cao
+  - Tong Che
+  - Ke Chen
+  - Yuxiao Chen
+  - Jenna Diamond
+  - Yifan Ding
+  - Wenhao Ding
+  - Liang Feng
+  - Greg Heinrich
+  - Jack Huang
+  - Peter Karkus
+  - Boyi Li
+  - Pinyi Li
+  - Tsung-Yi Lin
+  - Dongran Liu
+  - Ming-Yu Liu
+  - Langechuan Liu
+  - Zhijian Liu
+  - Jason Lu
+  - Yunxiang Mao
+  - Pavlo Molchanov
+  - Lindsey Pavao
+  - Zhenghao Peng
+  - Mike Ranzinger
+  - Ed Schmerling
+  - Shida Shen
+  - Yunfei Shi
+  - Sarah Tariq
+  - Ran Tian
+  - Tilman Wekel
+  - Xinshuo Weng
+  - Tianjun Xiao
+  - Eric Yang
+  - Xiaodong Yang
+  - Yurong You
+  - Xiaohui Zeng
+  - Wenyuan Zhang
+  - Boris Ivanovic
+  - Marco Pavone
+  arxiv_categories:
+  - cs.RO
+  - cs.AI
+  - cs.LG
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2510.26125
+  title: 'WOD-E2E: Waymo Open Dataset for End-to-End Driving in Challenging Long-tail Scenarios'
+  date: '2025-10-30'
+  updated: '2025-11-13'
+  url: https://arxiv.org/abs/2510.26125
+  abstract: 'Vision-based end-to-end (E2E) driving has garnered significant interest in the research community due to its
+    scalability and synergy with multimodal large language models (MLLMs). However, current E2E driving benchmarks primarily
+    feature nominal scenarios, failing to adequately test the true potential of these systems. Furthermore, existing open-loop
+    evaluation metrics often fall short in capturing the multi-modal nature of driving or effectively evaluating performance
+    in long-tail scenarios. To address these gaps, we introduce the Waymo Open Dataset for End-to-End Driving (WOD-E2E). WOD-E2E
+    contains 4,021 driving segments (approximately 12 hours), specifically curated for challenging long-tail scenarios that
+    that are rare in daily life with an occurring frequency of less than 0.03%. Concretely, each segment in WOD-E2E includes
+    the high-level routing information, ego states, and 360-degree camera views from 8 surrounding cameras. To evaluate the
+    E2E driving performance on these long-tail situations, we propose a novel open-loop evaluation metric: Rater Feedback
+    Score (RFS). Unlike conventional metrics that measure the distance between predicted way points and the logs, RFS measures
+    how closely the predicted trajectory matches rater-annotated trajectory preference labels. We have released rater preference
+    labels for all WOD-E2E validation set segments, while the held out test set labels have been used for the 2025 WOD-E2E
+    Challenge. Through our work, we aim to foster state of the art research into generalizable, robust, and safe end-to-end
+    autonomous driving agents capable of handling complex real-world situations.'
+  authors:
+  - Runsheng Xu
+  - Hubert Lin
+  - Wonseok Jeon
+  - Hao Feng
+  - Yuliang Zou
+  - Liting Sun
+  - John Gorman
+  - Ekaterina Tolstaya
+  - Sarah Tang
+  - Brandyn White
+  - Ben Sapp
+  - Mingxing Tan
+  - Jyh-Jing Hwang
+  - Dragomir Anguelov
+  arxiv_categories:
+  - cs.CV
+  - cs.AI
+  source_signals:
+  - curated:autonomous-driving-post-training
+  direction_hints:
+  - embodied-vla
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:autonomous-driving-post-training
+- id: arxiv:2510.21473
+  title: 'MRO: Enhancing Reasoning in Diffusion Language Models via Multi-Reward Optimization'
+  date: '2025-10-24'
+  updated: '2025-10-24'
+  url: https://arxiv.org/abs/2510.21473
+  abstract: 'Recent advances in diffusion language models (DLMs) have presented a promising alternative to traditional autoregressive
+    large language models (LLMs). However, DLMs still lag behind LLMs in reasoning performance, especially as the number of
+    denoising steps decreases. Our analysis reveals that this shortcoming arises primarily from the independent generation
+    of masked tokens across denoising steps, which fails to capture the token correlation. In this paper, we define two types
+    of token correlation: intra-sequence correlation and inter-sequence correlation, and demonstrate that enhancing these
+    correlations improves reasoning performance. To this end, we propose a Multi-Reward Optimization (MRO) approach, which
+    encourages DLMs to consider the token correlation during the denoising process. More specifically, our MRO approach leverages
+    test-time scaling, reject sampling, and reinforcement learning to directly optimize the token correlation with multiple
+    elaborate rewards. Additionally, we introduce group step and importance sampling strategies to mitigate reward variance
+    and enhance sampling efficiency. Through extensive experiments, we demonstrate that MRO not only improves reasoning performance
+    but also achieves significant sampling speedups while maintaining high performance on reasoning benchmarks.'
+  authors:
+  - Chenglong Wang
+  - Yang Gan
+  - Hang Zhou
+  - Chi Hu
+  - Yongyu Mu
+  - Kai Song
+  - Murun Yang
+  - Bei Li
+  - Chunliang Zhang
+  - Tongran Liu
+  - Jingbo Zhu
+  - Zhengtao Yu
+  - Tong Xiao
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - reasoning-self-improvement
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training
+- id: arxiv:2510.19871
+  title: 'From Denoising to Refining: A Corrective Framework for Vision-Language Diffusion Model'
+  date: '2025-10-22'
+  updated: '2025-10-22'
+  url: https://arxiv.org/abs/2510.19871
+  abstract: 'Discrete diffusion models have emerged as a promising direction for vision-language tasks, offering bidirectional
+    context modeling and theoretical parallelization. However, their practical application is severely hindered by a train-inference
+    discrepancy, which leads to catastrophic error cascades: initial token errors during parallel decoding pollute the generation
+    context, triggering a chain reaction of compounding errors and leading to syntactic errors and semantic hallucinations.
+    To address this fundamental challenge, we reframe the generation process from passive denoising to active refining. We
+    introduce ReDiff, a refining-enhanced diffusion framework that teaches the model to identify and correct its own errors.
+    Our approach features a two-stage training process: first, we instill a foundational revision capability by training the
+    model to revise synthetic errors; second, we implement a novel online self-correction loop where the model is explicitly
+    trained to revise its own flawed drafts by learning from an expert''s corrections. This mistake-driven learning endows
+    the model with the crucial ability to revisit and refine its already generated output, effectively breaking the error
+    cascade. Extensive experiments demonstrate that ReDiff significantly improves the coherence and factual accuracy of generated
+    content, enabling stable and efficient parallel generation far superior to traditional denoising methods. Our codes and
+    models are available at https://rediff-hku.github.io/.'
+  authors:
+  - Yatai Ji
+  - Teng Wang
+  - Yuying Ge
+  - Zhiheng Liu
+  - Sidi Yang
+  - Ying Shan
+  - Ping Luo
+  arxiv_categories:
+  - cs.CL
+  source_signals:
+  - curated:diffusion-language-post-training
+  direction_hints:
+  - multimodal
+  status: candidate
+  review_priority: 1
+  rule_score: 3
+  rule_reasons:
+  - curated-source:diffusion-language-post-training


### PR DESCRIPTION
Cross-source audit found 614 unique arXiv IDs across seven specialist indexes. This first balanced batch contains 180 metadata-enriched candidates with source provenance and direction hints. Every record still requires an explicit curator accept/reject decision before entering the main atlas.