### PR TITLE
Show every monthly audit gap and harden coverage PRs

### DIFF
--- a/.github/workflows/backfill-radar.yml
+++ b/.github/workflows/backfill-radar.yml
@@ -58,6 +58,13 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: |
+            COVERAGE.md
+            README.md
+            LABELS.md
+            data/**
+            directions/**
+            docs/**
           commit-message: "radar: audit direction-month academic coverage"
           branch: radar/monthly-coverage
           delete-branch: true

--- a/directions/agentic.md
+++ b/directions/agentic.md
@@ -8,12 +8,15 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08) · [Jul](#2026-07)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2023](#2023) — [Feb](#2023-02)
-- [2021](#2021) — [Dec](#2021-12)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓54 · [Jul](#2026-07) ◐20 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐32 · [Nov](#2025-11) ◐17 · [Oct](#2025-10) ◐21 · [Sep](#2025-09) ◐30 · [Aug](#2025-08) ✓14 · [Jul](#2025-07) ✓11 · [Jun](#2025-06) ✓13 · [May](#2025-05) ✓16 · [Apr](#2025-04) ✓6 · [Mar](#2025-03) ✓8 · [Feb](#2025-02) ✓7 · [Jan](#2025-01) ✓2
+- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2023](#2023) — [Feb](#2023-02) ◐1
+- [2021](#2021) — [Dec](#2021-12) ◐1
 
 <a id="2026"></a>
 

--- a/directions/distillation.md
+++ b/directions/distillation.md
@@ -8,10 +8,13 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08) · [Jul](#2026-07) · [Jun](#2026-06) · [May](#2026-05) · [Apr](#2026-04) · [Mar](#2026-03) · [Jan](#2026-01)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓85 · [Jul](#2026-07) ◐7 · [Jun](#2026-06) ◐3 · [May](#2026-05) ◐5 · [Apr](#2026-04) ◐4 · [Mar](#2026-03) ◐3 · Feb ⏳ · [Jan](#2026-01) ◐1
+- [2025](#2025) — [Dec](#2025-12) ✓4 · [Nov](#2025-11) ✓6 · [Oct](#2025-10) ✓6 · [Sep](#2025-09) ✓3 · [Aug](#2025-08) ✓6 · [Jul](#2025-07) ✓5 · [Jun](#2025-06) ✓3 · [May](#2025-05) ✓4 · [Apr](#2025-04) ✓2 · [Mar](#2025-03) ✓4 · [Feb](#2025-02) ✓5 · Jan ✓0
+- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
 
 <a id="2026"></a>
 

--- a/directions/embodied-vla.md
+++ b/directions/embodied-vla.md
@@ -8,11 +8,14 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08) · [Jul](#2026-07)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2023](#2023) — [Jul](#2023-07)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓20 · [Jul](#2026-07) ◐19 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ✓23 · [Nov](#2025-11) ✓17 · [Oct](#2025-10) ✓19 · [Sep](#2025-09) ✓25 · [Aug](#2025-08) ✓7 · [Jul](#2025-07) ✓6 · [Jun](#2025-06) ✓16 · [May](#2025-05) ✓21 · [Apr](#2025-04) ✓1 · [Mar](#2025-03) ✓11 · [Feb](#2025-02) ✓3 · [Jan](#2025-01) ✓1
+- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2023](#2023) — [Jul](#2023-07) ◐1
 
 <a id="2026"></a>
 

--- a/directions/generative-media.md
+++ b/directions/generative-media.md
@@ -8,11 +8,14 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2023](#2023) — [Nov](#2023-11) · [May](#2023-05)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓33 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐9 · [Nov](#2025-11) ◐11 · [Oct](#2025-10) ◐11 · [Sep](#2025-09) ◐5 · [Aug](#2025-08) ◐7 · [Jul](#2025-07) ◐5 · [Jun](#2025-06) ◐6 · [May](#2025-05) ◐8 · [Apr](#2025-04) ◐1 · [Mar](#2025-03) ◐3 · [Feb](#2025-02) ◐18 · [Jan](#2025-01) ✓2
+- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2023](#2023) — [Nov](#2023-11) ◐1 · [May](#2023-05) ◐1
 
 <a id="2026"></a>
 

--- a/directions/multimodal.md
+++ b/directions/multimodal.md
@@ -8,11 +8,14 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08) · [Jul](#2026-07)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2023](#2023) — [Sep](#2023-09) · [Apr](#2023-04)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓68 · [Jul](#2026-07) ◐4 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐7 · [Nov](#2025-11) ◐11 · [Oct](#2025-10) ◐8 · [Sep](#2025-09) ◐12 · [Aug](#2025-08) ◐8 · [Jul](#2025-07) ◐9 · [Jun](#2025-06) ◐13 · [May](#2025-05) ◐9 · [Apr](#2025-04) ◐5 · [Mar](#2025-03) ◐5 · [Feb](#2025-02) ◐15 · [Jan](#2025-01) ◐6
+- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2023](#2023) — [Sep](#2023-09) ◐1 · [Apr](#2023-04) ◐1
 
 <a id="2026"></a>
 

--- a/directions/preference-alignment.md
+++ b/directions/preference-alignment.md
@@ -8,13 +8,15 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08) · [Jul](#2026-07)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2024](#2024) — [May](#2024-05) · [Feb](#2024-02)
-- [2023](#2023) — [May](#2023-05)
-- [2022](#2022) — [Dec](#2022-12) · [Mar](#2022-03)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓58 · [Jul](#2026-07) ◐18 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐68 · [Nov](#2025-11) ◐76 · [Oct](#2025-10) ◐76 · [Sep](#2025-09) ◐79 · [Aug](#2025-08) ◐72 · [Jul](#2025-07) ◐79 · [Jun](#2025-06) ◐75 · [May](#2025-05) ◐77 · [Apr](#2025-04) ◐82 · [Mar](#2025-03) ◐83 · [Feb](#2025-02) ◐72 · [Jan](#2025-01) ✓72
+- [2024](#2024) — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · [May](#2024-05) ◐1 · Apr ⏳ · Mar ⏳ · [Feb](#2024-02) ◐1 · Jan ⏳
+- [2023](#2023) — [May](#2023-05) ◐1
+- [2022](#2022) — [Dec](#2022-12) ◐1 · [Mar](#2022-03) ◐1
 
 <a id="2026"></a>
 

--- a/directions/reasoning-self-improvement.md
+++ b/directions/reasoning-self-improvement.md
@@ -8,12 +8,14 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08) · [Jul](#2026-07)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2024](#2024) — [Mar](#2024-03) · [Jan](#2024-01)
-- [2022](#2022) — [Mar](#2022-03)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓48 · [Jul](#2026-07) ◐14 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐18 · [Nov](#2025-11) ◐12 · [Oct](#2025-10) ◐12 · [Sep](#2025-09) ◐14 · [Aug](#2025-08) ◐13 · [Jul](#2025-07) ◐14 · [Jun](#2025-06) ◐14 · [May](#2025-05) ◐12 · [Apr](#2025-04) ◐13 · [Mar](#2025-03) ◐8 · [Feb](#2025-02) ◐16 · [Jan](#2025-01) ✓8
+- [2024](#2024) — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · [Mar](#2024-03) ◐1 · Feb ⏳ · [Jan](#2024-01) ◐1
+- [2022](#2022) — [Mar](#2022-03) ◐1
 
 <a id="2026"></a>
 

--- a/directions/reinforcement-learning.md
+++ b/directions/reinforcement-learning.md
@@ -8,12 +8,14 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2024](#2024) — [Feb](#2024-02)
-- [2017](#2017) — [Jul](#2017-07)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓58 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐40 · [Nov](#2025-11) ◐40 · [Oct](#2025-10) ◐45 · [Sep](#2025-09) ◐26 · [Aug](#2025-08) ◐42 · [Jul](#2025-07) ✓43 · [Jun](#2025-06) ◐31 · [May](#2025-05) ◐31 · [Apr](#2025-04) ✓29 · [Mar](#2025-03) ✓18 · [Feb](#2025-02) ✓11 · [Jan](#2025-01) ✓2
+- [2024](#2024) — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · [Feb](#2024-02) ◐1 · Jan ⏳
+- [2017](#2017) — [Jul](#2017-07) ◐1
 
 <a id="2026"></a>
 

--- a/directions/reward-verifiers.md
+++ b/directions/reward-verifiers.md
@@ -8,11 +8,14 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2023](#2023) — [May](#2023-05)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓223 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐26 · [Nov](#2025-11) ◐32 · [Oct](#2025-10) ◐29 · [Sep](#2025-09) ◐49 · [Aug](#2025-08) ◐23 · [Jul](#2025-07) ◐27 · [Jun](#2025-06) ◐28 · [May](#2025-05) ◐27 · [Apr](#2025-04) ◐17 · [Mar](#2025-03) ◐23 · [Feb](#2025-02) ◐17 · [Jan](#2025-01) ◐13
+- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2023](#2023) — [May](#2023-05) ◐1
 
 <a id="2026"></a>
 

--- a/directions/supervised-adaptation.md
+++ b/directions/supervised-adaptation.md
@@ -8,12 +8,15 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 *Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*
 
-## Timeline directory
+## Monthly audit directory
 
-- [2026](#2026) — [Aug](#2026-08)
-- [2025](#2025) — [Dec](#2025-12) · [Nov](#2025-11) · [Oct](#2025-10) · [Sep](#2025-09) · [Aug](#2025-08) · [Jul](#2025-07) · [Jun](#2025-06) · [May](#2025-05) · [Apr](#2025-04) · [Mar](#2025-03) · [Feb](#2025-02) · [Jan](#2025-01)
-- [2023](#2023) — [Oct](#2023-10)
-- [2022](#2022) — [Dec](#2022-12)
+`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
+
+- [2026](#2026) — [Aug](#2026-08) ✓115 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2025](#2025) — [Dec](#2025-12) ◐64 · [Nov](#2025-11) ◐66 · [Oct](#2025-10) ◐61 · [Sep](#2025-09) ◐64 · [Aug](#2025-08) ◐66 · [Jul](#2025-07) ◐63 · [Jun](#2025-06) ◐59 · [May](#2025-05) ◐63 · [Apr](#2025-04) ◐55 · [Mar](#2025-03) ◐70 · [Feb](#2025-02) ◐55 · [Jan](#2025-01) ✓52
+- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2023](#2023) — [Oct](#2023-10) ◐1
+- [2022](#2022) — [Dec](#2022-12) ◐1
 
 <a id="2026"></a>
 

--- a/radar/render.py
+++ b/radar/render.py
@@ -91,19 +91,46 @@ def direction_page(direction: dict, records: list[dict]) -> str:
     selected = [paper for paper in records if paper["direction"] == direction["id"]]
     curated_count = sum(not paper.get("discovery_candidate") for paper in selected)
     candidate_count = len(selected) - curated_count
-    years = sorted({str(paper["date"])[:4] for paper in selected}, reverse=True)
+    audit_path = ROOT / "data" / "monthly_audit.yaml"
+    audit_cells = (load_yaml(audit_path) or {"cells": []})["cells"] if audit_path.exists() else []
+    audit = {cell["month"]: cell for cell in audit_cells if cell["direction"] == direction["id"]}
+    latest_complete_month = (dt.date.today().replace(day=1) - dt.timedelta(days=1)).replace(day=1)
+    dense_months = []
+    cursor = dt.date(2024, 1, 1)
+    while cursor <= latest_complete_month:
+        dense_months.append(cursor.strftime("%Y-%m"))
+        cursor = (cursor.replace(day=28) + dt.timedelta(days=4)).replace(day=1)
+    existing_months = {str(paper["date"])[:7] for paper in selected}
+    displayed_months = sorted(set(dense_months) | existing_months, reverse=True)
+    years = sorted({month[:4] for month in displayed_months}, reverse=True)
     directory = []
     for year in years:
-        months = sorted({str(paper["date"])[5:7] for paper in selected if str(paper["date"]).startswith(year)}, reverse=True)
-        month_links = " · ".join(f"[{dt.date(2000, int(month), 1).strftime('%b')}](#{year}-{month})" for month in months)
-        directory.append(f"- [{year}](#{year}) — {month_links}")
+        month_items = []
+        for month_key in [month for month in displayed_months if month.startswith(year)]:
+            month = month_key[5:7]
+            month_name = dt.date(2000, int(month), 1).strftime("%b")
+            count = sum(str(paper["date"]).startswith(month_key) for paper in selected)
+            cell = audit.get(month_key)
+            if count:
+                state = "✓" if cell and cell.get("complete") and not cell.get("error") else "◐"
+                month_items.append(f"[{month_name}](#{month_key}) {state}{count}")
+            elif cell and cell.get("complete") and not cell.get("error"):
+                month_items.append(f"{month_name} ✓0")
+            elif cell and (cell.get("error") or not cell.get("complete")):
+                month_items.append(f"{month_name} ⚠")
+            else:
+                month_items.append(f"{month_name} ⏳")
+        year_has_papers = any(str(paper["date"]).startswith(year) for paper in selected)
+        year_label = f"[{year}](#{year})" if year_has_papers else year
+        directory.append(f"- {year_label} — " + " · ".join(month_items))
     return (
         f"# {direction['title']}\n\n"
         "[← Back to the atlas](../README.md)\n\n"
         f"**{len(selected)} papers**: {curated_count} curated and {candidate_count} academic discovery candidates.\n\n"
         "Curated entries include a reviewed key idea and tags. 🔎 entries were found directly through academic search and remain visibly provisional until primary-paper review.\n\n"
         "*Institution names, when shown, come from Semantic Scholar author profiles and may differ from affiliations at publication time.*\n\n"
-        "## Timeline directory\n\n"
+        "## Monthly audit directory\n\n"
+        "`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.\n\n"
         + "\n".join(directory)
         + "\n\n"
         + render_papers(selected)


### PR DESCRIPTION
Direction pages now display every month from 2024-01 through the latest completed month with explicit audited, zero, incomplete, failed, or unaudited states. The monthly workflow now limits its PR payload to data and generated pages so concurrent workflow edits cannot make the final push fail.