### PR TITLE
Add a linked audit section for every month

### DIFF
--- a/directions/agentic.md
+++ b/directions/agentic.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓54 · [Jul](#2026-07) ◐20 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓54 · [Jul](#2026-07) ◐20 · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐32 · [Nov](#2025-11) ◐17 · [Oct](#2025-10) ◐21 · [Sep](#2025-09) ◐30 · [Aug](#2025-08) ✓14 · [Jul](#2025-07) ✓11 · [Jun](#2025-06) ✓13 · [May](#2025-05) ✓16 · [Apr](#2025-04) ✓6 · [Mar](#2025-03) ✓8 · [Feb](#2025-02) ✓7 · [Jan](#2025-01) ✓2
-- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ⏳
 - [2023](#2023) — [Feb](#2023-02) ◐1
 - [2021](#2021) — [Dec](#2021-12) ◐1
 
@@ -25,6 +25,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 242 academic records · 109 eligible · checked 2026-09-01T14:35:59.084088+00:00.
 
 - 🔎 **[Learning to Reason and Use Tools through Unsupervised Fine-Tuning in Task-Oriented Dialog Systems](https://arxiv.org/abs/2608.30426)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -300,6 +302,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - 🔎 **[Echoverse: Deep, Evolving Environments for Training Computer-Use Agents at Scale](https://arxiv.org/abs/2607.28074)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-07-30 · `academic-query-vote` · `arxiv-backfill`  
   Labels: `Verifier`  
@@ -400,6 +404,54 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `SFT` · `Agent` · `Tool Use` · `Long-horizon` · `VLM` · `Robotics` · `Reasoning`  
   Authors: Boyu Mi, Mengchen Ma, Yifei Yao, Xing Gao, Junting Chen, Yangzi Li, Zihou Zhu, Guohao Li, et al.
 
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -407,6 +459,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 49 eligible · checked 2026-09-01T13:32:56.711113+00:00.
 
 - 🔎 **[AGRO-SQL: Agentic Group-Relative Optimization with High-Fidelity Data Synthesis](https://arxiv.org/abs/2512.23366)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-29 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -572,6 +626,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### November
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 28 eligible · checked 2026-09-01T13:31:16.020814+00:00.
+
 - 🔎 **[MIRA: Multimodal Iterative Reasoning Agent for Image Editing](https://arxiv.org/abs/2511.21087)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-26 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `SFT` · `GRPO` · `Tool Use` · `Multi-turn` · `Multimodal` · `Reasoning`  
@@ -660,6 +716,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-10"></a>
 
 ### October
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 33 eligible · checked 2026-09-01T13:29:06.865457+00:00.
 
 - 🔎 **[Consistently Simulating Human Personas with Multi-Turn Reinforcement Learning](https://arxiv.org/abs/2511.00222)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -769,6 +827,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-09"></a>
 
 ### September
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 37 eligible · checked 2026-09-01T13:03:35.826077+00:00.
 
 - 🔎 **[Scaling Generalist Data-Analytic Agents](https://arxiv.org/abs/2509.25084)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-29 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -924,6 +984,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### August
 
+> **Audit status:** ✓ Complete · scanned 77 academic records · 21 eligible · checked 2026-09-01T13:01:55.426086+00:00.
+
 - 🔎 **[LLM-Driven Policy Diffusion: Enhancing Generalization in Offline Reinforcement Learning](https://arxiv.org/abs/2509.00347)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Diffusion`  
@@ -998,6 +1060,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ✓ Complete · scanned 80 academic records · 17 eligible · checked 2026-09-01T13:00:07.120301+00:00.
+
 - 🔎 **[AutoTIR: Autonomous Tools Integrated Reasoning via Reinforcement Learning](https://arxiv.org/abs/2507.21836)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-29 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Tool Use` · `Reasoning`  
@@ -1056,6 +1120,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-06"></a>
 
 ### June
+
+> **Audit status:** ✓ Complete · scanned 82 academic records · 19 eligible · checked 2026-09-01T12:58:29.669288+00:00.
 
 - 🔎 **[MEM1: Learning to Synergize Memory and Reasoning for Efficient Long-Horizon Agents](https://arxiv.org/abs/2506.15841)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-18 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1125,6 +1191,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-05"></a>
 
 ### May
+
+> **Audit status:** ✓ Complete · scanned 93 academic records · 22 eligible · checked 2026-09-01T12:56:02.776927+00:00.
 
 - 🔎 **[SPA-RL: Reinforcing LLM Agents via Stepwise Progress Attribution](https://arxiv.org/abs/2505.20732)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-27 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1210,6 +1278,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ✓ Complete · scanned 51 academic records · 18 eligible · checked 2026-09-01T12:54:06.888252+00:00.
+
 - 🔎 **[Quantum-Enhanced Reinforcement Learning for Power Grid Security Assessment](https://arxiv.org/abs/2504.14412)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-19 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Agent`  
@@ -1243,6 +1313,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-03"></a>
 
 ### March
+
+> **Audit status:** ✓ Complete · scanned 75 academic records · 12 eligible · checked 2026-09-01T12:52:53.249587+00:00.
 
 - 🔎 **[An Organizationally-Oriented Approach to Enhancing Explainability and Control in Multi-Agent Reinforcement Learning](https://arxiv.org/abs/2503.23615)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1288,6 +1360,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### February
 
+> **Audit status:** ✓ Complete · scanned 68 academic records · 11 eligible · checked 2026-09-01T12:51:30.208911+00:00.
+
 - 🔎 **[Advancing Language Multi-Agent Learning with Credit Re-Assignment for Interactive Environment Generalization](https://arxiv.org/abs/2502.14496)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-20 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Agent`  
@@ -1327,6 +1401,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ✓ Complete · scanned 46 academic records · 7 eligible · checked 2026-09-01T12:50:46.969594+00:00.
+
 - 🔎 **[PIMAEX: Multi-Agent Exploration through Peer Incentivization](https://arxiv.org/abs/2501.01266)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-02 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Agent`  
@@ -1337,6 +1413,106 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Reward Model` · `PRM` · `Synthetic Data` · `Tool Use` · `Reasoning`  
   Authors: Vaskar Nath, Pranav Raja, Claire Yoon, Sean Hendryx
 
+<a id="2024"></a>
+
+## 2024
+
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2023"></a>
 
 ## 2023
@@ -1344,6 +1520,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-02"></a>
 
 ### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Toolformer: Language Models Can Teach Themselves to Use Tools](https://arxiv.org/abs/2302.04761)** — Lets a model generate and filter its own API-call demonstrations, then learns when and how to invoke tools.  
   2023-02-09 · `tool-use` · `self-supervision` · `api`  
@@ -1358,6 +1536,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2021-12"></a>
 
 ### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[WebGPT: Browser-assisted question-answering with human feedback](https://arxiv.org/abs/2112.09332)** — Trains a language model to browse the web and answer with citations using demonstrations and human preference feedback.  
   2021-12-17 · `tool-use` · `browsing` · `imitation-learning` · `reward-modeling`  

--- a/directions/distillation.md
+++ b/directions/distillation.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓85 · [Jul](#2026-07) ◐7 · [Jun](#2026-06) ◐3 · [May](#2026-05) ◐5 · [Apr](#2026-04) ◐4 · [Mar](#2026-03) ◐3 · Feb ⏳ · [Jan](#2026-01) ◐1
-- [2025](#2025) — [Dec](#2025-12) ✓4 · [Nov](#2025-11) ✓6 · [Oct](#2025-10) ✓6 · [Sep](#2025-09) ✓3 · [Aug](#2025-08) ✓6 · [Jul](#2025-07) ✓5 · [Jun](#2025-06) ✓3 · [May](#2025-05) ✓4 · [Apr](#2025-04) ✓2 · [Mar](#2025-03) ✓4 · [Feb](#2025-02) ✓5 · Jan ✓0
-- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓85 · [Jul](#2026-07) ◐7 · [Jun](#2026-06) ◐3 · [May](#2026-05) ◐5 · [Apr](#2026-04) ◐4 · [Mar](#2026-03) ◐3 · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ◐1
+- [2025](#2025) — [Dec](#2025-12) ✓4 · [Nov](#2025-11) ✓6 · [Oct](#2025-10) ✓6 · [Sep](#2025-09) ✓3 · [Aug](#2025-08) ✓6 · [Jul](#2025-07) ✓5 · [Jun](#2025-06) ✓3 · [May](#2025-05) ✓4 · [Apr](#2025-04) ✓2 · [Mar](#2025-03) ✓4 · [Feb](#2025-02) ✓5 · [Jan](#2025-01) ✓0
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ⏳
 
 <a id="2026"></a>
 
@@ -23,6 +23,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 133 academic records · 121 eligible · checked 2026-09-01T14:35:23.251185+00:00.
 
 - 🔎 **[Does On-Policy Distillation Really Distill? From Noisy Teacher to Self-Improvement](https://arxiv.org/abs/2608.31046)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -454,6 +456,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - **[Adaptive FastOPD: Progress-Aware Rollout Horizon Expansion for Efficient On-Policy Distillation](https://arxiv.org/abs/2607.29494)** — Expands the student rollout horizon only when learning at the current boundary plateaus, reducing wasted long-horizon sampling.  
   2026-07-31 · `on-policy-distillation` · `adaptive-horizon` · `efficiency` · `multi-turn`  
   Labels: `OPD` · `Distillation` · `On-policy` · `Multi-turn` · `Long-horizon`  
@@ -495,6 +499,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### June
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - **[OPID: On-Policy Skill Distillation for Agentic Reinforcement Learning](https://arxiv.org/abs/2606.26790)** — Extracts hierarchical hindsight skills from completed student trajectories and combines skill-conditioned token guidance with outcome-based reinforcement learning.  
   2026-06-25 · `on-policy-distillation` · `skill-distillation` · `hindsight` · `agentic-rl`  
   Labels: `Distillation` · `On-policy` · `Agent`  
@@ -513,6 +519,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-05"></a>
 
 ### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Trust Region On-Policy Distillation](https://arxiv.org/abs/2606.01249)** — Restricts distillation to reliable teacher regions using clipping, masking, and forward-KL controls, with optional off-policy guidance outside the trust region.  
   2026-05-31 · `on-policy-distillation` · `trust-region` · `clipping` · `stability`  
@@ -543,6 +551,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - **[Beyond SFT-to-RL: Pre-alignment via Black-Box On-Policy Distillation for Multimodal RL](https://arxiv.org/abs/2604.28123)** — Inserts a black-box response-level distribution-alignment stage between SFT and RLVR using specialized perception and reasoning discriminators.  
   2026-04-30 · `on-policy-distillation` · `distribution-alignment` · `rlvr` · `mixture-of-experts` · [code](https://github.com/XIAO4579/PRISM)  
   Labels: `OPD` · `Distillation` · `SFT` · `RLVR` · `On-policy` · `Multimodal` · `Reasoning`  
@@ -568,6 +578,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### March
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - **[Revisiting On-Policy Distillation: Empirical Failure Modes and Simple Fixes](https://arxiv.org/abs/2603.25562)** — Diagnoses sampled-token distillation failures and evaluates top-K local support matching, top-p rollouts, and special-token masking as simple remedies.  
   2026-03-26 · `on-policy-distillation` · `failure-analysis` · `support-matching` · `stability`  
   Labels: `OPD` · `Distillation` · `On-policy`  
@@ -584,9 +596,19 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `OPD` · `Distillation` · `On-policy`  
   Authors: Woogyeol Jin, Taywon Min, Yongjin Yang, Dennis Wei, Yi Zhou, Swanand Ravindra Kadhe, Nathalie Baracaldo, Kimin Lee
 
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2026-01"></a>
 
 ### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Self-Distilled Reasoner: On-Policy Self-Distillation for Large Language Models](https://arxiv.org/abs/2601.18734)** — Uses one model as both privileged-trace teacher and question-only student, matching their token distributions along student-generated reasoning trajectories.  
   2026-01-26 · `on-policy-self-distillation` · `privileged-information` · `reasoning` · `token-level`  
@@ -600,6 +622,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ✓ Complete · scanned 29 academic records · 6 eligible · checked 2026-09-01T13:32:40.148017+00:00.
 
 - 🔎 **[GTR-Turbo: Merged Checkpoint is Secretly a Free Teacher for Agentic VLM Training](https://arxiv.org/abs/2512.13043)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-15 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -624,6 +648,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-11"></a>
 
 ### November
+
+> **Audit status:** ✓ Complete · scanned 33 academic records · 8 eligible · checked 2026-09-01T13:30:54.803352+00:00.
 
 - 🔎 **[FT-NCFM: An Influence-Aware Data Distillation Framework for Efficient VLA Models](https://arxiv.org/abs/2511.16233)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-20 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -659,6 +685,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### October
 
+> **Audit status:** ✓ Complete · scanned 28 academic records · 9 eligible · checked 2026-09-01T13:28:50.593644+00:00.
+
 - 🔎 **[LC-Opt: Benchmarking Reinforcement Learning and Agentic AI for End-to-End Liquid Cooling Optimization in Data Centers](https://arxiv.org/abs/2511.00116)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `Agent`  
@@ -693,6 +721,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### September
 
+> **Audit status:** ✓ Complete · scanned 24 academic records · 5 eligible · checked 2026-09-01T13:03:18.234041+00:00.
+
 - 🔎 **[SAC Flow: Sample-Efficient Reinforcement Learning of Flow-Based Policies via Velocity-Reparameterized Sequential Modeling](https://arxiv.org/abs/2509.25756)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `Off-policy` · `Robotics`  
@@ -711,6 +741,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 30 academic records · 8 eligible · checked 2026-09-01T13:01:34.897603+00:00.
 
 - 🔎 **[One-Step Flow Q-Learning: Addressing the Diffusion Policy Bottleneck in Offline Reinforcement Learning](https://arxiv.org/abs/2508.13904)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-19 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -746,6 +778,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ✓ Complete · scanned 22 academic records · 5 eligible · checked 2026-09-01T12:59:38.666437+00:00.
+
 - 🔎 **[FairReason: Balancing Reasoning and Social Bias in MLLMs](https://arxiv.org/abs/2507.23067)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `SFT` · `Multimodal` · `Reasoning`  
@@ -775,6 +809,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### June
 
+> **Audit status:** ✓ Complete · scanned 18 academic records · 7 eligible · checked 2026-09-01T12:57:43.856037+00:00.
+
 - 🔎 **[Decentralized Consensus Inference-based Hierarchical Reinforcement Learning for Multi-Constrained UAV Pursuit-Evasion Game](https://arxiv.org/abs/2506.18126)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-22 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `PPO`  
@@ -793,6 +829,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-05"></a>
 
 ### May
+
+> **Audit status:** ✓ Complete · scanned 29 academic records · 5 eligible · checked 2026-09-01T12:55:27.922644+00:00.
 
 - 🔎 **[How Ensembles of Distilled Policies Improve Generalisation in Reinforcement Learning](https://arxiv.org/abs/2505.16581)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-22 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -818,6 +856,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ✓ Complete · scanned 21 academic records · 8 eligible · checked 2026-09-01T12:53:54.539246+00:00.
+
 - 🔎 **[LangWBC: Language-directed Humanoid Whole-Body Control via End-to-end Learning](https://arxiv.org/abs/2504.21738)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation`  
@@ -831,6 +871,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-03"></a>
 
 ### March
+
+> **Audit status:** ✓ Complete · scanned 20 academic records · 5 eligible · checked 2026-09-01T12:52:39.432501+00:00.
 
 - 🔎 **[MoLe-VLA: Dynamic Layer-skipping Vision Language Action Model via Mixture-of-Layers for Efficient Robot Manipulation](https://arxiv.org/abs/2503.20384)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-26 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -856,6 +898,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### February
 
+> **Audit status:** ✓ Complete · scanned 26 academic records · 7 eligible · checked 2026-09-01T12:51:22.371092+00:00.
+
 - 🔎 **[Sim-to-Real Reinforcement Learning for Vision-Based Dexterous Manipulation on Humanoids](https://arxiv.org/abs/2502.20396)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-27 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation`  
@@ -880,3 +924,111 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   2025-02-02 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation`  
   Authors: Wenzheng Jiang, Ji Wang, Xiongtao Zhang, Weidong Bao, Cheston Tan, Flint Xiaofeng Fan
+
+<a id="2025-01"></a>
+
+### January
+
+> **Audit status:** ✓ Complete · scanned 10 academic records · 0 eligible · checked 2026-09-01T12:50:42.463543+00:00.
+
+_No visible paper records in this cell yet._
+
+<a id="2024"></a>
+
+## 2024
+
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._

--- a/directions/embodied-vla.md
+++ b/directions/embodied-vla.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓20 · [Jul](#2026-07) ◐19 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓20 · [Jul](#2026-07) ◐19 · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ✓23 · [Nov](#2025-11) ✓17 · [Oct](#2025-10) ✓19 · [Sep](#2025-09) ✓25 · [Aug](#2025-08) ✓7 · [Jul](#2025-07) ✓6 · [Jun](#2025-06) ✓16 · [May](#2025-05) ✓21 · [Apr](#2025-04) ✓1 · [Mar](#2025-03) ✓11 · [Feb](#2025-02) ✓3 · [Jan](#2025-01) ✓1
-- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ⏳
 - [2023](#2023) — [Jul](#2023-07) ◐1
 
 <a id="2026"></a>
@@ -24,6 +24,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 97 academic records · 49 eligible · checked 2026-09-01T14:37:12.030728+00:00.
 
 - 🔎 **[Self-Aware Active Learning Enables Continual Improvement in Autonomous Driving](https://arxiv.org/abs/2608.29772)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-30 · `academic-query-vote` · `arxiv-backfill`  
@@ -129,6 +131,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - 🔎 **[CLIFT: Turning Gemini Robotics On-Device into Humanoid Specialists via Non-Invasive Closed-Loop Iterative Fine-Tuning](https://arxiv.org/abs/2607.29172)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-07-31 · `academic-query-vote` · `arxiv-backfill`  
   Labels: `SFT` · `Robotics`  
@@ -224,6 +228,54 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Distillation` · `Multimodal` · `Diffusion` · `VLA` · `Robotics`  
   Authors: Andreas Sochopoulos, Esmeralda S. Whitammer, Nikolaos Tsagkas, João Moura, Michael Gienger, Sethu Vijayakumar
 
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -231,6 +283,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ✓ Complete · scanned 61 academic records · 31 eligible · checked 2026-09-01T13:33:17.625421+00:00.
 
 - 🔎 **[Semi-Supervised Diversity-Aware Domain Adaptation for 3D Object detection](https://arxiv.org/abs/2512.24922)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -351,6 +405,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### November
 
+> **Audit status:** ✓ Complete · scanned 64 academic records · 29 eligible · checked 2026-09-01T13:31:36.804538+00:00.
+
 - 🔎 **[MindPower: Enabling Theory-of-Mind Reasoning in VLM-based Embodied Agents](https://arxiv.org/abs/2511.23055)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-28 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Multimodal` · `VLM` · `Robotics` · `Reasoning`  
@@ -439,6 +495,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-10"></a>
 
 ### October
+
+> **Audit status:** ✓ Complete · scanned 56 academic records · 29 eligible · checked 2026-09-01T13:29:28.270829+00:00.
 
 - 🔎 **[Human-in-the-loop Online Rejection Sampling for Robotic Manipulation](https://arxiv.org/abs/2510.26406)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -538,6 +596,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-09"></a>
 
 ### September
+
+> **Audit status:** ✓ Complete · scanned 67 academic records · 37 eligible · checked 2026-09-01T13:03:57.588160+00:00.
 
 - 🔎 **[Can AI Perceive Physical Danger and Intervene?](https://arxiv.org/abs/2509.21651)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-25 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -668,6 +728,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### August
 
+> **Audit status:** ✓ Complete · scanned 23 academic records · 14 eligible · checked 2026-09-01T13:02:20.739208+00:00.
+
 - 🔎 **[Galaxea Open-World Dataset and G0 Dual-System VLA Model](https://arxiv.org/abs/2509.00576)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Curriculum` · `Long-horizon` · `Multimodal` · `VLM` · `VLA` · `Robotics`  
@@ -707,6 +769,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ✓ Complete · scanned 31 academic records · 16 eligible · checked 2026-09-01T13:00:33.731877+00:00.
+
 - 🔎 **[Assistax: A Multi-Agent Hardware-Accelerated Reinforcement Learning Benchmark for Assistive Robotics](https://arxiv.org/abs/2507.21638)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-29 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Robotics`  
@@ -740,6 +804,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-06"></a>
 
 ### June
+
+> **Audit status:** ✓ Complete · scanned 49 academic records · 26 eligible · checked 2026-09-01T12:58:49.947816+00:00.
 
 - 🔎 **[Unified Vision-Language-Action Model](https://arxiv.org/abs/2506.19850)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-24 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -824,6 +890,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-05"></a>
 
 ### May
+
+> **Audit status:** ✓ Complete · scanned 46 academic records · 28 eligible · checked 2026-09-01T12:56:38.684503+00:00.
 
 - 🔎 **[Intrinsic Goals for Autonomous Agents: Model-Based Exploration in Virtual Zebrafish Predicts Ethological Behavior and Whole-Brain Dynamics](https://arxiv.org/abs/2506.00138)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -934,6 +1002,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ✓ Complete · scanned 20 academic records · 9 eligible · checked 2026-09-01T12:54:26.418104+00:00.
+
 - 🔎 **[Preference-Driven Active 3D Scene Representation for Robotic Inspection in Nuclear Decommissioning](https://arxiv.org/abs/2504.02161)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-02 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `RLHF` · `Robotics`  
@@ -942,6 +1012,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-03"></a>
 
 ### March
+
+> **Audit status:** ✓ Complete · scanned 33 academic records · 19 eligible · checked 2026-09-01T12:53:12.649269+00:00.
 
 - 🔎 **[Can Test-Time Scaling Improve World Foundation Model?](https://arxiv.org/abs/2503.24320)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1002,6 +1074,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### February
 
+> **Audit status:** ✓ Complete · scanned 24 academic records · 12 eligible · checked 2026-09-01T12:51:43.224030+00:00.
+
 - 🔎 **[Generative Models in Decision Making: A Survey](https://arxiv.org/abs/2502.17100)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-24 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Multimodal` · `Autonomous Driving` · `Hallucination`  
@@ -1021,10 +1095,112 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ✓ Complete · scanned 13 academic records · 4 eligible · checked 2026-09-01T12:50:58.209819+00:00.
+
 - 🔎 **[Capability-Aware Shared Hypernetworks for Flexible Heterogeneous Multi-Robot Coordination](https://arxiv.org/abs/2501.06058)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-10 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: pending  
   Authors: Kevin Fu, Shalin Anand Jain, Pierce Howell, Harish Ravichandar
+
+<a id="2024"></a>
+
+## 2024
+
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
 
 <a id="2023"></a>
 
@@ -1033,6 +1209,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-07"></a>
 
 ### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[RT-2: Vision-Language-Action Models Transfer Web Knowledge to Robotic Control](https://arxiv.org/abs/2307.15818)** — Co-fine-tunes web-scale vision-language knowledge and robot trajectories by expressing actions as tokens.  
   2023-07-28 · `vla` · `co-fine-tuning` · `embodied`  

--- a/directions/generative-media.md
+++ b/directions/generative-media.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓33 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓33 · [Jul](#2026-07) ⏳ · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐9 · [Nov](#2025-11) ◐11 · [Oct](#2025-10) ◐11 · [Sep](#2025-09) ◐5 · [Aug](#2025-08) ◐7 · [Jul](#2025-07) ◐5 · [Jun](#2025-06) ◐6 · [May](#2025-05) ◐8 · [Apr](#2025-04) ◐1 · [Mar](#2025-03) ◐3 · [Feb](#2025-02) ◐18 · [Jan](#2025-01) ✓2
-- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ⏳
 - [2023](#2023) — [Nov](#2023-11) ◐1 · [May](#2023-05) ◐1
 
 <a id="2026"></a>
@@ -24,6 +24,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 244 academic records · 51 eligible · checked 2026-09-01T14:37:07.710657+00:00.
 
 - 🔎 **[Sycophantic Agreement Transfers with Neutral Data via Contrastive Preference Optimization](https://arxiv.org/abs/2608.31079)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -190,6 +192,62 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `GRPO` · `On-policy`  
   Authors: Guanrou Yang, Tian Tan, Qian Chen, Ziyang Ma, Yakun Song, Zhikang Niu, Qi Chen, Wenming Tu, et al.
 
+<a id="2026-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -197,6 +255,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 24 eligible · checked 2026-09-01T13:33:13.370252+00:00.
 
 - 🔎 **[Dichotomous Diffusion Policy Optimization](https://arxiv.org/abs/2601.00898)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -246,6 +306,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-11"></a>
 
 ### November
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 30 eligible · checked 2026-09-01T13:31:32.573894+00:00.
 
 - 🔎 **[Goal-Driven Reward by Video Diffusion Models for Reinforcement Learning](https://arxiv.org/abs/2512.00961)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -306,6 +368,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### October
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 27 eligible · checked 2026-09-01T13:29:23.857300+00:00.
+
 - 🔎 **[Off-policy Reinforcement Learning with Model-based Exploration Augmentation](https://arxiv.org/abs/2510.25529)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-29 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `On-policy` · `Off-policy`  
@@ -365,6 +429,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### September
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 22 eligible · checked 2026-09-01T13:03:51.876974+00:00.
+
 - 🔎 **[TR2-D2: Tree Search Guided Trajectory-Aware Fine-Tuning for Discrete Diffusion](https://arxiv.org/abs/2509.25171)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-29 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Diffusion`  
@@ -393,6 +459,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-08"></a>
 
 ### August
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 20 eligible · checked 2026-09-01T13:02:16.795052+00:00.
 
 - 🔎 **[Drive As You Like: Multi-Head Diffusion with Reinforcement Learning for Personalized Driving](https://arxiv.org/abs/2508.16947)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-23 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -433,6 +501,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 15 eligible · checked 2026-09-01T13:00:27.328237+00:00.
+
 - 🔎 **[DmC: Nearest Neighbor Guidance Diffusion Model for Offline Cross-domain Reinforcement Learning](https://arxiv.org/abs/2507.20499)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-28 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Diffusion`  
@@ -461,6 +531,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-06"></a>
 
 ### June
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 15 eligible · checked 2026-09-01T12:58:46.165800+00:00.
 
 - 🔎 **[Uncertainty-aware Diffusion and Reinforcement Learning for Joint Plane Localization and Anomaly Diagnosis in 3D Ultrasound](https://arxiv.org/abs/2506.23538)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -495,6 +567,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-05"></a>
 
 ### May
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 21 eligible · checked 2026-09-01T12:56:34.727702+00:00.
 
 - 🔎 **[ADG: Ambient Diffusion-Guided Dataset Recovery for Corruption-Robust Offline Reinforcement Learning](https://arxiv.org/abs/2505.23871)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-29 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -540,6 +614,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 17 eligible · checked 2026-09-01T12:54:23.363796+00:00.
+
 - 🔎 **[Target Concrete Score Matching: A Holistic Framework for Discrete Diffusion](https://arxiv.org/abs/2504.16431)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-23 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `Diffusion`  
@@ -548,6 +624,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-03"></a>
 
 ### March
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 12 eligible · checked 2026-09-01T12:53:09.167936+00:00.
 
 - 🔎 **[High-Fidelity Diffusion Face Swapping with ID-Constrained Facial Conditioning](https://arxiv.org/abs/2503.22179)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-28 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -567,6 +645,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-02"></a>
 
 ### February
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 25 eligible · checked 2026-09-01T12:51:41.189343+00:00.
 
 - 🔎 **[NavigateDiff: Visual Predictors are Zero-Shot Navigation Assistants](https://arxiv.org/abs/2502.13894)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-19 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -662,6 +742,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ✓ Complete · scanned 96 academic records · 9 eligible · checked 2026-09-01T12:50:56.304231+00:00.
+
 - 🔎 **[FDPP: Fine-tune Diffusion Policy with Human Preference](https://arxiv.org/abs/2501.08259)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-14 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Robotics`  
@@ -672,6 +754,106 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Multimodal` · `VLM` · `Diffusion` · `VLA`  
   Authors: Alhassan Mumuni, Fuseini Mumuni
 
+<a id="2024"></a>
+
+## 2024
+
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2023"></a>
 
 ## 2023
@@ -679,6 +861,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-11"></a>
 
 ### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Diffusion Model Alignment Using Direct Preference Optimization](https://arxiv.org/abs/2311.12908)** — Adapts direct preference optimization to diffusion likelihoods to align image generation without a learned reward model.  
   2023-11-22 · `diffusion` · `preference-optimization` · `dpo`  
@@ -688,6 +872,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-05"></a>
 
 ### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Training Diffusion Models with Reinforcement Learning](https://arxiv.org/abs/2305.13301)** — Treats diffusion denoising as a multi-step decision process so image generators can optimize downstream rewards directly.  
   2023-05-22 · `diffusion` · `reinforcement-learning` · `ddpo`  

--- a/directions/multimodal.md
+++ b/directions/multimodal.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓68 · [Jul](#2026-07) ◐4 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓68 · [Jul](#2026-07) ◐4 · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐7 · [Nov](#2025-11) ◐11 · [Oct](#2025-10) ◐8 · [Sep](#2025-09) ◐12 · [Aug](#2025-08) ◐8 · [Jul](#2025-07) ◐9 · [Jun](#2025-06) ◐13 · [May](#2025-05) ◐9 · [Apr](#2025-04) ◐5 · [Mar](#2025-03) ◐5 · [Feb](#2025-02) ◐15 · [Jan](#2025-01) ◐6
-- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ⏳
 - [2023](#2023) — [Sep](#2023-09) ◐1 · [Apr](#2023-04) ◐1
 
 <a id="2026"></a>
@@ -24,6 +24,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 392 academic records · 127 eligible · checked 2026-09-01T14:36:52.837845+00:00.
 
 - 🔎 **[LightNav-0: Eliciting VLM Spatial Intelligence for Generalist Embodied Navigation](https://arxiv.org/abs/2608.30935)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -369,6 +371,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - 🔎 **[Reasoning to Regulate: Chain-of-Thought for Traffic Rule Understanding](https://arxiv.org/abs/2607.24199)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-07-27 · `academic-query-vote` · `arxiv-backfill`  
   Labels: `SFT` · `GRPO` · `Verifier` · `VLM` · `Autonomous Driving` · `Reasoning`  
@@ -389,6 +393,54 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `SFT` · `DPO` · `Preference Optimization` · `RLHF` · `PPO` · `Multimodal`  
   Authors: Thi Kim Trang Vo, Nghia Hieu Nguyen, Ha Minh Tan
 
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -396,6 +448,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 29 eligible · checked 2026-09-01T13:33:04.969435+00:00.
 
 - 🔎 **[RoboMIND 2.0: A Multimodal, Bimanual Mobile Manipulation Dataset for Generalizable Embodied Intelligence](https://arxiv.org/abs/2512.24653)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -435,6 +489,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-11"></a>
 
 ### November
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 33 eligible · checked 2026-09-01T13:31:24.811878+00:00.
 
 - 🔎 **[Adapting Like Humans: A Metacognitive Agent with Test-time Reasoning](https://arxiv.org/abs/2511.23262)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-28 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -495,6 +551,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### October
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 32 eligible · checked 2026-09-01T13:29:14.973220+00:00.
+
 - 🔎 **[Emu3.5: Native Multimodal Models are World Learners](https://arxiv.org/abs/2510.26583)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Long-horizon` · `Multimodal` · `Image Generation` · `Reasoning`  
@@ -538,6 +596,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-09"></a>
 
 ### September
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 36 eligible · checked 2026-09-01T13:03:43.771249+00:00.
 
 - 🔎 **[MLA: A Multisensory Language-Action Model for Multimodal Understanding and Forecasting in Robotic Manipulation](https://arxiv.org/abs/2509.26642)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -603,6 +663,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### August
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 29 eligible · checked 2026-09-01T13:02:06.577577+00:00.
+
 - 🔎 **[Text Reinforcement for Multimodal Time Series Forecasting](https://arxiv.org/abs/2509.00687)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Multimodal`  
@@ -646,6 +708,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-07"></a>
 
 ### July
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 35 eligible · checked 2026-09-01T13:00:17.376924+00:00.
 
 - 🔎 **[A Survey of Multimodal Ophthalmic Diagnostics: From Task-Specific Approaches to Foundational Models](https://arxiv.org/abs/2508.03734)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -695,6 +759,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-06"></a>
 
 ### June
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 26 eligible · checked 2026-09-01T12:58:37.608750+00:00.
 
 - 🔎 **[Multi-Timescale Hierarchical Reinforcement Learning for Unified Behavior and Control of Autonomous Driving](https://arxiv.org/abs/2506.23771)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -765,6 +831,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### May
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 41 eligible · checked 2026-09-01T12:56:13.104564+00:00.
+
 - 🔎 **[MMedAgent-RL: Optimizing Multi-Agent Collaboration for Multimodal Medical Reasoning](https://arxiv.org/abs/2506.00555)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Curriculum` · `Multimodal` · `VLM` · `Reasoning`  
@@ -814,6 +882,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 22 eligible · checked 2026-09-01T12:54:14.805293+00:00.
+
 - 🔎 **[Reinforced MLLM: A Survey on RL-Based Reasoning in Multimodal Large Language Models](https://arxiv.org/abs/2504.21277)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Multimodal` · `Reasoning`  
@@ -843,6 +913,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### March
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 36 eligible · checked 2026-09-01T12:53:00.980589+00:00.
+
 - 🔎 **[Learning Adaptive Dexterous Grasping from Single Demonstrations](https://arxiv.org/abs/2503.20208)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-26 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Curriculum` · `VLM`  
@@ -871,6 +943,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-02"></a>
 
 ### February
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 29 eligible · checked 2026-09-01T12:51:35.617136+00:00.
 
 - 🔎 **[Multimodal Dreaming: A Global Workspace Approach to World Model-Based Reinforcement Learning](https://arxiv.org/abs/2502.21142)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-28 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -951,6 +1025,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 19 eligible · checked 2026-09-01T12:50:52.387953+00:00.
+
 - 🔎 **[RLS3: RL-Based Synthetic Sample Selection to Enhance Spatial Reasoning in Vision-Language Models for Indoor Autonomous Perception](https://arxiv.org/abs/2501.18880)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Synthetic Data` · `VLM` · `Reasoning`  
@@ -981,6 +1057,106 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Reward Model` · `Multimodal` · `Image Generation` · `Reasoning` · `Hallucination`  
   Authors: Ruixiang Jiang, Changwen Chen
 
+<a id="2024"></a>
+
+## 2024
+
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2023"></a>
 
 ## 2023
@@ -988,6 +1164,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-09"></a>
 
 ### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[LLaVA-RLHF: Aligning Large Multimodal Models with Factually Augmented RLHF](https://arxiv.org/abs/2309.14525)** — Adds factually grounded preference feedback and RLHF to improve multimodal helpfulness and reduce hallucination.  
   2023-09-25 · `rlhf` · `hallucination` · `multimodal-alignment`  
@@ -998,6 +1176,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-04"></a>
 
 ### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Visual Instruction Tuning](https://arxiv.org/abs/2304.08485)** — Uses language-model-generated visual instruction data to adapt a vision-language assistant end to end.  
   2023-04-17 · `instruction-tuning` · `synthetic-data` · `vlm`  

--- a/directions/preference-alignment.md
+++ b/directions/preference-alignment.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓58 · [Jul](#2026-07) ◐18 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓58 · [Jul](#2026-07) ◐18 · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐68 · [Nov](#2025-11) ◐76 · [Oct](#2025-10) ◐76 · [Sep](#2025-09) ◐79 · [Aug](#2025-08) ◐72 · [Jul](#2025-07) ◐79 · [Jun](#2025-06) ◐75 · [May](#2025-05) ◐77 · [Apr](#2025-04) ◐82 · [Mar](#2025-03) ◐83 · [Feb](#2025-02) ◐72 · [Jan](#2025-01) ✓72
-- [2024](#2024) — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · [May](#2024-05) ◐1 · Apr ⏳ · Mar ⏳ · [Feb](#2024-02) ◐1 · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ◐1 · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ◐1 · [Jan](#2024-01) ⏳
 - [2023](#2023) — [May](#2023-05) ◐1
 - [2022](#2022) — [Dec](#2022-12) ◐1 · [Mar](#2022-03) ◐1
 
@@ -25,6 +25,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 111 academic records · 90 eligible · checked 2026-09-01T14:33:31.811222+00:00.
 
 - 🔎 **[Scaling Large Reasoning Models beyond Human Supervision: A Path toward Superintelligence](https://arxiv.org/abs/2608.31075)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -320,6 +322,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - 🔎 **[SciForma: Structure-Faithful Generation of Scientific Diagrams](https://arxiv.org/abs/2607.18091)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-07-20 · `academic-query-vote` · `arxiv-backfill`  
   Labels: `SFT` · `DPO` · `Preference Optimization`  
@@ -410,6 +414,54 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `DPO` · `Preference Optimization`  
   Authors: Hua Qu, Yifan Li, Xiaodong Yuan
 
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -417,6 +469,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 80 eligible · checked 2026-09-01T13:32:20.385737+00:00.
 
 - 🔎 **[ResponseRank: Data-Efficient Reward Modeling through Preference Strength Learning](https://arxiv.org/abs/2512.25023)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -761,6 +815,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-11"></a>
 
 ### November
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 85 eligible · checked 2026-09-01T13:30:08.770439+00:00.
 
 - 🔎 **[When Human Preferences Flip: An Instance-Dependent Robust Loss for RLHF](https://arxiv.org/abs/2512.00709)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1146,6 +1202,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### October
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 82 eligible · checked 2026-09-01T13:28:31.198319+00:00.
+
 - 🔎 **[MolChord: Structure-Sequence Alignment for Protein-Guided Drug Design](https://arxiv.org/abs/2510.27671)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `DPO` · `Preference Optimization`  
@@ -1529,6 +1587,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-09"></a>
 
 ### September
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 83 eligible · checked 2026-09-01T13:02:56.765441+00:00.
 
 - 🔎 **[Free Lunch Alignment of Text-to-Image Diffusion Models without Preference Image Pairs](https://arxiv.org/abs/2509.25771)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1929,6 +1989,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### August
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 86 eligible · checked 2026-09-01T13:01:10.471647+00:00.
+
 - 🔎 **[RPRO: Ranked Preference Reinforcement Optimization for Enhancing Medical QA and Diagnostic Reasoning](https://arxiv.org/abs/2509.00974)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Preference Optimization` · `Reasoning`  
@@ -2292,6 +2354,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-07"></a>
 
 ### July
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 89 eligible · checked 2026-09-01T12:59:22.359194+00:00.
 
 - 🔎 **[3D-R1: Enhancing Reasoning in 3D VLMs for Unified Scene Understanding](https://arxiv.org/abs/2507.23478)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -2692,6 +2756,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### June
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 85 eligible · checked 2026-09-01T12:57:25.370649+00:00.
+
 - 🔎 **[$μ^2$Tokenizer: Differentiable Multi-Scale Multi-Modal Tokenizer for Radiology Report Generation](https://arxiv.org/abs/2507.00316)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `DPO` · `Preference Optimization` · `Multimodal` · `Reasoning`  
@@ -3070,6 +3136,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-05"></a>
 
 ### May
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 87 eligible · checked 2026-09-01T12:55:09.134724+00:00.
 
 - 🔎 **[CLARIFY: Contrastive Preference Reinforcement Learning for Untangling Ambiguous Queries](https://arxiv.org/abs/2506.00388)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -3459,6 +3527,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-04"></a>
 
 ### April
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 96 eligible · checked 2026-09-01T12:53:39.142015+00:00.
 
 - 🔎 **[Base Models Beat Aligned Models at Randomness and Creativity](https://arxiv.org/abs/2505.00047)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -3873,6 +3943,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-03"></a>
 
 ### March
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 92 eligible · checked 2026-09-01T12:52:20.044416+00:00.
 
 - 🔎 **[Learning a Canonical Basis of Human Preferences from Binary Ratings](https://arxiv.org/abs/2503.24150)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -4293,6 +4365,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### February
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 90 eligible · checked 2026-09-01T12:51:12.834366+00:00.
+
 - 🔎 **[Gradient Imbalance in Direct Preference Optimization](https://arxiv.org/abs/2502.20847)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-28 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `DPO` · `Preference Optimization` · `RLHF` · `PPO`  
@@ -4656,6 +4730,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-01"></a>
 
 ### January
+
+> **Audit status:** ✓ Complete · scanned 86 academic records · 81 eligible · checked 2026-09-01T12:50:33.043921+00:00.
 
 - 🔎 **[Best Policy Learning from Trajectory Preference Feedback](https://arxiv.org/abs/2501.18873)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -5021,9 +5097,67 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ## 2024
 
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2024-05"></a>
 
 ### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[SimPO: Simple Preference Optimization with a Reference-Free Reward](https://arxiv.org/abs/2405.14734)** — Uses average response log probability as an implicit reward and removes the reference model from preference optimization.  
   2024-05-23 · `reference-free` · `preference-optimization` · `simpo`  
@@ -5031,14 +5165,40 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Authors: Yu Meng, Mengzhou Xia, Danqi Chen  
   Institutions*: Princeton University; University of Virginia
 
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2024-02"></a>
 
 ### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[KTO: Model Alignment as Prospect Theoretic Optimization](https://arxiv.org/abs/2402.01306)** — Learns from unpaired desirable and undesirable examples using a prospect-theoretic utility objective.  
   2024-02-02 · `binary-feedback` · `offline` · `kto`  
   Labels: pending  
   Authors: Kawin Ethayarajh, Winnie Xu, Niklas Muennighoff, Dan Jurafsky, Douwe Kiela
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
 
 <a id="2023"></a>
 
@@ -5047,6 +5207,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-05"></a>
 
 ### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Direct Preference Optimization: Your Language Model is Secretly a Reward Model](https://arxiv.org/abs/2305.18290)** — Converts the RLHF objective into a direct classification-style loss over preferred and rejected responses.  
   2023-05-29 · `offline` · `pairwise-preference` · `dpo`  
@@ -5062,6 +5224,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### December
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - **[Constitutional AI: Harmlessness from AI Feedback](https://arxiv.org/abs/2212.08073)** — Uses written principles and model-generated critiques to reduce dependence on direct human harmlessness labels.  
   2022-12-15 · `rlaif` · `critique` · `revision` · `constitutional-ai`  
   Labels: `RLAIF`  
@@ -5071,6 +5235,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2022-03"></a>
 
 ### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Training language models to follow instructions with human feedback](https://arxiv.org/abs/2203.02155)** — Establishes the SFT-to-reward-model-to-RLHF pipeline for aligning language models with human intent.  
   2022-03-04 · `sft` · `reward-modeling` · `rlhf` · `ppo`  

--- a/directions/reasoning-self-improvement.md
+++ b/directions/reasoning-self-improvement.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓48 · [Jul](#2026-07) ◐14 · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓48 · [Jul](#2026-07) ◐14 · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐18 · [Nov](#2025-11) ◐12 · [Oct](#2025-10) ◐12 · [Sep](#2025-09) ◐14 · [Aug](#2025-08) ◐13 · [Jul](#2025-07) ◐14 · [Jun](#2025-06) ◐14 · [May](#2025-05) ◐12 · [Apr](#2025-04) ◐13 · [Mar](#2025-03) ◐8 · [Feb](#2025-02) ◐16 · [Jan](#2025-01) ✓8
-- [2024](#2024) — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · [Mar](#2024-03) ◐1 · Feb ⏳ · [Jan](#2024-01) ◐1
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ◐1 · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ◐1
 - [2022](#2022) — [Mar](#2022-03) ◐1
 
 <a id="2026"></a>
@@ -24,6 +24,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 261 academic records · 117 eligible · checked 2026-09-01T14:35:40.332569+00:00.
 
 - 🔎 **[S3Gym: Can LLMs Turn Self-Testing and Self-Judging into Self-Improvement?](https://arxiv.org/abs/2608.31100)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -269,6 +271,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
 - 🔎 **[Translation with Thought: Difficulty-Adaptive Reasoning via Reinforcement Learning for Multi-Domain Machine Translation](https://arxiv.org/abs/2607.29287)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-07-31 · `academic-query-vote` · `arxiv-backfill`  
   Labels: `Distillation` · `SFT` · `Reasoning`  
@@ -339,6 +343,54 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Distillation` · `SFT` · `Multimodal` · `Reasoning`  
   Authors: Isak Hwang, Yoon Pyo Lee, Syed Bahauddin Alam
 
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -346,6 +398,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 48 eligible · checked 2026-09-01T13:32:47.907855+00:00.
 
 - 🔎 **[VLN-MME: Diagnosing MLLMs as Language-guided Visual Navigation agents](https://arxiv.org/abs/2512.24851)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -441,6 +495,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### November
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 36 eligible · checked 2026-09-01T13:31:03.844767+00:00.
+
 - 🔎 **[Text-to-SQL as Dual-State Reasoning: Integrating Adaptive Context and Progressive Generation](https://arxiv.org/abs/2511.21402)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-26 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Reasoning`  
@@ -505,6 +561,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### October
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 38 eligible · checked 2026-09-01T13:28:58.156359+00:00.
+
 - 🔎 **[Counteracting Matthew Effect in Self-Improvement of LVLMs through Head-Tail Re-balancing](https://arxiv.org/abs/2510.26474)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Self-improvement` · `VLM` · `Reasoning`  
@@ -568,6 +626,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-09"></a>
 
 ### September
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 44 eligible · checked 2026-09-01T13:03:26.341886+00:00.
 
 - 🔎 **[Memory-Driven Self-Improvement for Decision Making with Large Language Models](https://arxiv.org/abs/2509.26340)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -643,6 +703,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### August
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 39 eligible · checked 2026-09-01T13:01:47.360013+00:00.
+
 - 🔎 **[LLM-Assisted Iterative Evolution with Swarm Intelligence Toward SuperBrain](https://arxiv.org/abs/2509.00510)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `Self-improvement`  
@@ -711,6 +773,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-07"></a>
 
 ### July
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 41 eligible · checked 2026-09-01T12:59:46.611528+00:00.
 
 - 🔎 **[Zebra-CoT: A Dataset for Interleaved Vision Language Reasoning](https://arxiv.org/abs/2507.16746)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-22 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -786,6 +850,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### June
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 36 eligible · checked 2026-09-01T12:58:08.657831+00:00.
+
 - 🔎 **[MiCo: Multi-image Contrast for Reinforcement Visual Reasoning](https://arxiv.org/abs/2506.22434)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-27 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `VLM` · `Reasoning`  
@@ -860,6 +926,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### May
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 42 eligible · checked 2026-09-01T12:55:51.909196+00:00.
+
 - 🔎 **[CodeSense: a Real-World Benchmark and Dataset for Code Semantic Reasoning](https://arxiv.org/abs/2506.00750)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Reasoning` · `Code`  
@@ -923,6 +991,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-04"></a>
 
 ### April
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 40 eligible · checked 2026-09-01T12:54:02.390621+00:00.
 
 - 🔎 **[SAS-Prompt: Large Language Models as Numerical Optimizers for Robot Self-Improvement](https://arxiv.org/abs/2504.20459)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-29 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -993,6 +1063,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### March
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 26 eligible · checked 2026-09-01T12:52:47.808846+00:00.
+
 - 🔎 **[Large Language and Reasoning Models are Shallow Disjunctive Reasoners](https://arxiv.org/abs/2503.23487)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Reasoning`  
@@ -1036,6 +1108,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-02"></a>
 
 ### February
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 37 eligible · checked 2026-09-01T12:51:27.878136+00:00.
 
 - 🔎 **[Self-Training Elicits Concise Reasoning in Large Language Models](https://arxiv.org/abs/2502.20122)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-27 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1121,6 +1195,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ✓ Complete · scanned 64 academic records · 21 eligible · checked 2026-09-01T12:50:44.805468+00:00.
+
 - 🔎 **[SETS: Leveraging Self-Verification and Self-Correction for Improved Test-Time Scaling](https://arxiv.org/abs/2501.19306)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Self-improvement` · `Reasoning` · `Code`  
@@ -1165,9 +1241,83 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ## 2024
 
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2024-03"></a>
 
 ### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Quiet-STaR: Language Models Can Teach Themselves to Think Before Speaking](https://arxiv.org/abs/2403.09629)** — Trains models to generate useful internal rationales at arbitrary positions in ordinary text.  
   2024-03-14 · `rationale` · `self-training` · `reasoning`  
@@ -1175,9 +1325,19 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Authors: Eric Zelikman, Georges Harik, Yijia Shao, Varuna Jayasiri, Nick Haber, Noah D. Goodman  
   Institutions*: Stanford University
 
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2024-01"></a>
 
 ### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Self-Rewarding Language Models](https://arxiv.org/abs/2401.10020)** — Iteratively uses the model itself as an instruction follower and judge to create preference data for further training.  
   2024-01-18 · `self-reward` · `iterative-dpo` · `llm-as-a-judge`  
@@ -1192,6 +1352,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2022-03"></a>
 
 ### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[STaR: Bootstrapping Reasoning With Reasoning](https://arxiv.org/abs/2203.14465)** — Iteratively trains on rationales that lead to correct answers and regenerates rationales for failed examples.  
   2022-03-28 · `rationale` · `bootstrapping` · `self-training`  

--- a/directions/reinforcement-learning.md
+++ b/directions/reinforcement-learning.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓58 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓58 · [Jul](#2026-07) ⏳ · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐40 · [Nov](#2025-11) ◐40 · [Oct](#2025-10) ◐45 · [Sep](#2025-09) ◐26 · [Aug](#2025-08) ◐42 · [Jul](#2025-07) ✓43 · [Jun](#2025-06) ◐31 · [May](#2025-05) ◐31 · [Apr](#2025-04) ✓29 · [Mar](#2025-03) ✓18 · [Feb](#2025-02) ✓11 · [Jan](#2025-01) ✓2
-- [2024](#2024) — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · [Feb](#2024-02) ◐1 · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ◐1 · [Jan](#2024-01) ⏳
 - [2017](#2017) — [Jul](#2017-07) ◐1
 
 <a id="2026"></a>
@@ -24,6 +24,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 221 academic records · 156 eligible · checked 2026-09-01T14:34:53.749317+00:00.
 
 - 🔎 **[GMTS: Gradient Magnitude-based Token Selection Improves RLVR Training for LLM Reasoning](https://arxiv.org/abs/2608.30632)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -315,6 +317,62 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Distillation` · `SFT` · `Curriculum` · `Multimodal` · `Reasoning`  
   Authors: Jiaxuan Kang, Siyu Chen, Mingda Li, Mingjie Liu, Tianyue Wang, Zhaoyang Wei, Yongheng Zhang, Yanchao Hao, et al.
 
+<a id="2026-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -322,6 +380,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 68 eligible · checked 2026-09-01T13:32:37.100631+00:00.
 
 - 🔎 **[SenseNova-MARS: Empowering Multimodal Agentic Reasoning and Search via Reinforcement Learning](https://arxiv.org/abs/2512.24330)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -527,6 +587,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### November
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 68 eligible · checked 2026-09-01T13:30:51.609305+00:00.
+
 - 🔎 **[ESPO: Entropy Importance Sampling Policy Optimization](https://arxiv.org/abs/2512.00499)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-29 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Reasoning` · `Math`  
@@ -730,6 +792,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-10"></a>
 
 ### October
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 77 eligible · checked 2026-09-01T13:28:47.657259+00:00.
 
 - 🔎 **[InfoFlow: Reinforcing Search Agent Via Reward Density Optimization](https://arxiv.org/abs/2510.26575)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -960,6 +1024,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### September
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 72 eligible · checked 2026-09-01T13:03:14.922804+00:00.
+
 - 🔎 **[Learning to Reason as Action Abstractions with Scalable Mid-Training RL](https://arxiv.org/abs/2509.25810)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `RLVR` · `Reasoning` · `Code`  
@@ -1093,6 +1159,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-08"></a>
 
 ### August
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 71 eligible · checked 2026-09-01T13:01:30.595148+00:00.
 
 - 🔎 **[RLFactory: A Plug-and-Play Reinforcement Learning Post-Training Framework for LLM Multi-Turn Tool-Use](https://arxiv.org/abs/2509.06980)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1307,6 +1375,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-07"></a>
 
 ### July
+
+> **Audit status:** ✓ Complete · scanned 95 academic records · 72 eligible · checked 2026-09-01T12:59:35.956216+00:00.
 
 - 🔎 **[One-Step Flow Policy Mirror Descent](https://arxiv.org/abs/2507.23675)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1527,6 +1597,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### June
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 70 eligible · checked 2026-09-01T12:57:40.992075+00:00.
+
 - 🔎 **[Unleashing Embodied Task Planning Ability in LLMs via Reinforcement Learning](https://arxiv.org/abs/2506.23127)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-29 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: pending  
@@ -1685,6 +1757,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-05"></a>
 
 ### May
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 68 eligible · checked 2026-09-01T12:55:24.848645+00:00.
 
 - 🔎 **[Mixed-R1: Unified Reward Perspective For Reasoning Capability in Multimodal Large Language Models](https://arxiv.org/abs/2505.24164)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1845,6 +1919,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ✓ Complete · scanned 74 academic records · 48 eligible · checked 2026-09-01T12:53:51.473485+00:00.
+
 - 🔎 **[GVPO: Group Variance Policy Optimization for Large Language Model Post-Training](https://arxiv.org/abs/2504.19599)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-28 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `GRPO` · `On-policy`  
@@ -1994,6 +2070,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### March
 
+> **Audit status:** ✓ Complete · scanned 49 academic records · 38 eligible · checked 2026-09-01T12:52:36.448809+00:00.
+
 - 🔎 **[Video-R1: Reinforcing Video Reasoning in MLLMs](https://arxiv.org/abs/2503.21776)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-27 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `SFT` · `GRPO` · `Multimodal` · `Reasoning`  
@@ -2088,6 +2166,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### February
 
+> **Audit status:** ✓ Complete · scanned 28 academic records · 21 eligible · checked 2026-09-01T12:51:20.260675+00:00.
+
 - 🔎 **[Evaluating System 1 vs. 2 Reasoning Approaches for Zero-Shot Time Series Forecasting: A Benchmark and Insights](https://arxiv.org/abs/2503.01895)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-27 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Multimodal` · `Reasoning`  
@@ -2147,6 +2227,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ✓ Complete · scanned 14 academic records · 10 eligible · checked 2026-09-01T12:50:40.637077+00:00.
+
 - **[DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning](https://arxiv.org/abs/2501.12948)** — Demonstrates that large-scale reinforcement learning with verifiable rewards can elicit and improve long-form reasoning.  
   2025-01-22 · `rlvr` · `grpo` · `reasoning` · `distillation`  
   Labels: `Distillation` · `RLVR` · `GRPO` · `Reasoning`  
@@ -2162,15 +2244,105 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ## 2024
 
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2024-02"></a>
 
 ### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[DeepSeekMath: Pushing the Limits of Mathematical Reasoning in Open Language Models](https://arxiv.org/abs/2402.03300)** — Introduces Group Relative Policy Optimization to improve mathematical reasoning without a separate critic model.  
   2024-02-05 · `grpo` · `mathematical-reasoning` · `reinforcement-learning`  
   Labels: `GRPO` · `Reasoning` · `Math`  
   Authors: Zhihong Shao, Peiyi Wang, Qihao Zhu, Runxin Xu, Junxiao Song, Xiao Bi, Haowei Zhang, Mingchuan Zhang, et al.  
   Institutions*: DeepSeek AI
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
 
 <a id="2017"></a>
 
@@ -2179,6 +2351,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2017-07"></a>
 
 ### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Proximal Policy Optimization Algorithms](https://arxiv.org/abs/1707.06347)** — Introduces a clipped surrogate objective that makes policy-gradient updates simpler and more stable.  
   2017-07-20 · `policy-optimization` · `on-policy` · `ppo`  

--- a/directions/reward-verifiers.md
+++ b/directions/reward-verifiers.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓223 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓223 · [Jul](#2026-07) ⏳ · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐26 · [Nov](#2025-11) ◐32 · [Oct](#2025-10) ◐29 · [Sep](#2025-09) ◐49 · [Aug](#2025-08) ◐23 · [Jul](#2025-07) ◐27 · [Jun](#2025-06) ◐28 · [May](#2025-05) ◐27 · [Apr](#2025-04) ◐17 · [Mar](#2025-03) ◐23 · [Feb](#2025-02) ◐17 · [Jan](#2025-01) ◐13
-- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ⏳
 - [2023](#2023) — [May](#2023-05) ◐1
 
 <a id="2026"></a>
@@ -24,6 +24,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 996 academic records · 341 eligible · checked 2026-09-01T14:34:38.988299+00:00.
 
 - 🔎 **[Reconciling Process Supervision with Outcome-Based Credit in Agentic Policy Optimization](https://arxiv.org/abs/2608.31077)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -1140,6 +1142,62 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Verifier` · `Reasoning`  
   Authors: Dahai Yu, Lin Jiang, Rongchao Xu, Guang Wang
 
+<a id="2026-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -1147,6 +1205,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 40 eligible · checked 2026-09-01T13:32:28.750575+00:00.
 
 - 🔎 **[Many Minds from One Model: Bayesian-Inspired Transformers for Population Diversity](https://arxiv.org/abs/2512.25063)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1281,6 +1341,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-11"></a>
 
 ### November
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 44 eligible · checked 2026-09-01T13:30:16.242627+00:00.
 
 - 🔎 **[IRPO: Boosting Image Restoration via Post-training GRPO](https://arxiv.org/abs/2512.00814)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1446,6 +1508,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### October
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 42 eligible · checked 2026-09-01T13:28:39.755906+00:00.
+
 - 🔎 **[Closing the Expression Gap in LLM Instructions via Socratic Questioning](https://arxiv.org/abs/2510.27410)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Reward Model`  
@@ -1594,6 +1658,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-09"></a>
 
 ### September
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 58 eligible · checked 2026-09-01T13:03:05.548930+00:00.
 
 - 🔎 **[Linking Process to Outcome: Conditional Reward Modeling for LLM Reasoning](https://arxiv.org/abs/2509.26578)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1844,6 +1910,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### August
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 38 eligible · checked 2026-09-01T13:01:19.196235+00:00.
+
 - 🔎 **[L-MARS: Legal Multi-Agent System with Agentic Search and Citation-Faithfulness Audit](https://arxiv.org/abs/2509.00761)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Verifier` · `Agent` · `Multi-turn`  
@@ -1962,6 +2030,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-07"></a>
 
 ### July
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 36 eligible · checked 2026-09-01T12:59:30.609389+00:00.
 
 - 🔎 **[Policy Learning from Large Vision-Language Model Feedback without Reward Modeling](https://arxiv.org/abs/2507.23391)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -2101,6 +2171,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-06"></a>
 
 ### June
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 47 eligible · checked 2026-09-01T12:57:33.185563+00:00.
 
 - 🔎 **[L0: Reinforcement Learning to Become General Agents](https://arxiv.org/abs/2506.23667)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -2246,6 +2318,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### May
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 43 eligible · checked 2026-09-01T12:55:16.890918+00:00.
+
 - 🔎 **[Accelerating Diffusion LLMs via Adaptive Parallel Decoding](https://arxiv.org/abs/2506.00413)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Verifier`  
@@ -2385,6 +2459,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 33 eligible · checked 2026-09-01T12:53:46.867642+00:00.
+
 - 🔎 **[Reinforcement Learning for Reasoning in Large Language Models with One Training Example](https://arxiv.org/abs/2504.20571)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-29 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `RLVR` · `GRPO` · `PPO` · `Reasoning` · `Math`  
@@ -2473,6 +2549,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-03"></a>
 
 ### March
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 42 eligible · checked 2026-09-01T12:52:32.663933+00:00.
 
 - 🔎 **[Crossing the Reward Bridge: Expanding RL with Verifiable Rewards Across Diverse Domains](https://arxiv.org/abs/2503.23829)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -2593,6 +2671,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### February
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 32 eligible · checked 2026-09-01T12:51:18.228247+00:00.
+
 - 🔎 **[Multi-Turn Code Generation Through Single-Step Rewards](https://arxiv.org/abs/2502.20380)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-27 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Reward Model` · `Verifier` · `Multi-turn` · `Code`  
@@ -2682,6 +2762,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 29 eligible · checked 2026-09-01T12:50:38.711344+00:00.
+
 - 🔎 **[Spend Wisely: Maximizing Post-Training Gains in Iterative Synthetic Data Bootstrapping](https://arxiv.org/abs/2501.18962)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Verifier` · `Synthetic Data` · `Reasoning` · `Math`  
@@ -2747,6 +2829,106 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Verifier` · `Diffusion` · `Image Generation`  
   Authors: Nanye Ma, Shangyuan Tong, Haolin Jia, Hexiang Hu, Yu-Chuan Su, Mingda Zhang, Xuan Yang, Yandong Li, et al.
 
+<a id="2024"></a>
+
+## 2024
+
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2023"></a>
 
 ## 2023
@@ -2754,6 +2936,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-05"></a>
 
 ### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Let's Verify Step by Step](https://arxiv.org/abs/2305.20050)** — Shows that supervising intermediate reasoning steps can outperform outcome-only reward supervision for mathematical reasoning.  
   2023-05-31 · `process-reward-model` · `verifier` · `reasoning`  

--- a/directions/supervised-adaptation.md
+++ b/directions/supervised-adaptation.md
@@ -12,9 +12,9 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 `✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.
 
-- [2026](#2026) — [Aug](#2026-08) ✓115 · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2026](#2026) — [Aug](#2026-08) ✓115 · [Jul](#2026-07) ⏳ · [Jun](#2026-06) ⏳ · [May](#2026-05) ⏳ · [Apr](#2026-04) ⏳ · [Mar](#2026-03) ⏳ · [Feb](#2026-02) ⏳ · [Jan](#2026-01) ⏳
 - [2025](#2025) — [Dec](#2025-12) ◐64 · [Nov](#2025-11) ◐66 · [Oct](#2025-10) ◐61 · [Sep](#2025-09) ◐64 · [Aug](#2025-08) ◐66 · [Jul](#2025-07) ◐63 · [Jun](#2025-06) ◐59 · [May](#2025-05) ◐63 · [Apr](#2025-04) ◐55 · [Mar](#2025-03) ◐70 · [Feb](#2025-02) ◐55 · [Jan](#2025-01) ✓52
-- 2024 — Dec ⏳ · Nov ⏳ · Oct ⏳ · Sep ⏳ · Aug ⏳ · Jul ⏳ · Jun ⏳ · May ⏳ · Apr ⏳ · Mar ⏳ · Feb ⏳ · Jan ⏳
+- [2024](#2024) — [Dec](#2024-12) ⏳ · [Nov](#2024-11) ⏳ · [Oct](#2024-10) ⏳ · [Sep](#2024-09) ⏳ · [Aug](#2024-08) ⏳ · [Jul](#2024-07) ⏳ · [Jun](#2024-06) ⏳ · [May](#2024-05) ⏳ · [Apr](#2024-04) ⏳ · [Mar](#2024-03) ⏳ · [Feb](#2024-02) ⏳ · [Jan](#2024-01) ⏳
 - [2023](#2023) — [Oct](#2023-10) ◐1
 - [2022](#2022) — [Dec](#2022-12) ◐1
 
@@ -25,6 +25,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2026-08"></a>
 
 ### August
+
+> **Audit status:** ✓ Complete · scanned 277 academic records · 175 eligible · checked 2026-09-01T14:33:25.233493+00:00.
 
 - 🔎 **[Sequential Trajectories and Simultaneous Blending: Multi-Emotion Modeling for Instruction-Following TTS](https://arxiv.org/abs/2608.30325)** — `discovery candidate`; awaiting primary-paper curation.  
   2026-08-31 · `academic-query-vote` · `arxiv-backfill`  
@@ -601,6 +603,62 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `SFT` · `Synthetic Data` · `Long-horizon`  
   Authors: Hao Yuan, Yuxin Wang, Lei Ji, Zhiwei Yu
 
+<a id="2026-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2026-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2025"></a>
 
 ## 2025
@@ -608,6 +666,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-12"></a>
 
 ### December
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 64 eligible · checked 2026-09-01T13:31:57.660762+00:00.
 
 - 🔎 **[Evolving, Not Training: Zero-Shot Reasoning Segmentation via Evolutionary Prompting](https://arxiv.org/abs/2512.24702)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-12-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -932,6 +992,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-11"></a>
 
 ### November
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 66 eligible · checked 2026-09-01T13:30:01.203913+00:00.
 
 - 🔎 **[Less is More: Resource-Efficient Low-Rank Adaptation](https://arxiv.org/abs/2512.00878)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-11-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1267,6 +1329,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### October
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 61 eligible · checked 2026-09-01T13:28:23.351824+00:00.
+
 - 🔎 **[Towards Understanding Self-play for LLM Reasoning](https://arxiv.org/abs/2510.27072)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-10-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `SFT` · `RLVR` · `Self-play` · `Reasoning` · `Math`  
@@ -1575,6 +1639,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-09"></a>
 
 ### September
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 64 eligible · checked 2026-09-01T13:02:48.821671+00:00.
 
 - 🔎 **[Thinking Sparks!: Emergent Attention Heads in Reasoning Models During Post Training](https://arxiv.org/abs/2509.25758)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-09-30 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -1899,6 +1965,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-08"></a>
 
 ### August
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 66 eligible · checked 2026-09-01T13:01:02.483424+00:00.
 
 - 🔎 **[CoreThink: A Symbolic Reasoning Layer to reason over Long Horizon Tasks with LLMs](https://arxiv.org/abs/2509.00971)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-08-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -2234,6 +2302,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### July
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 63 eligible · checked 2026-09-01T12:59:12.016527+00:00.
+
 - 🔎 **[MLLM-CTBench: A Benchmark for Continual Instruction Tuning with Reasoning Process Diagnosis](https://arxiv.org/abs/2508.08275)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-07-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `SFT` · `GRPO` · `On-policy` · `Multimodal` · `Reasoning`  
@@ -2553,6 +2623,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### June
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 59 eligible · checked 2026-09-01T12:57:02.560127+00:00.
+
 - 🔎 **[SPIRAL: Self-Play on Zero-Sum Games Incentivizes Reasoning via Multi-Agent Multi-Turn Reinforcement Learning](https://arxiv.org/abs/2506.24119)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-06-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `Distillation` · `SFT` · `RLVR` · `Self-play` · `Curriculum` · `Agent` · `Multi-turn` · `Reasoning`  
@@ -2851,6 +2923,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-05"></a>
 
 ### May
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 63 eligible · checked 2026-09-01T12:55:01.162506+00:00.
 
 - 🔎 **[Reasoning Like an Economist: Post-Training on Economic Problems Induces Strategic Generalization in LLMs](https://arxiv.org/abs/2506.00577)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-05-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -3171,6 +3245,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### April
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 55 eligible · checked 2026-09-01T12:53:31.687610+00:00.
+
 - 🔎 **[Iterative Tool Usage Exploration for Multimodal Agents via Step-wise Preference Tuning](https://arxiv.org/abs/2504.21561)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-04-30 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `SFT` · `Preference Optimization` · `RLAIF` · `Verifier` · `Multimodal` · `VLM`  
@@ -3449,6 +3525,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2025-03"></a>
 
 ### March
+
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 70 eligible · checked 2026-09-01T12:51:56.813537+00:00.
 
 - 🔎 **[Exploring the Effect of Reinforcement Learning on Video Understanding: Insights from SEED-Bench-R1](https://arxiv.org/abs/2503.24376)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-03-31 · `direction-month-query` · `arxiv-monthly-backfill`  
@@ -3804,6 +3882,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### February
 
+> **Audit status:** ◐ Incomplete or truncated · scanned 100 academic records · 55 eligible · checked 2026-09-01T12:51:07.411565+00:00.
+
 - 🔎 **[Jawaher: A Multidialectal Dataset of Arabic Proverbs for LLM Benchmarking](https://arxiv.org/abs/2503.00231)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-02-28 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `SFT` · `DPO` · `Preference Optimization` · `RLHF`  
@@ -4083,6 +4163,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 
 ### January
 
+> **Audit status:** ✓ Complete · scanned 94 academic records · 52 eligible · checked 2026-09-01T12:50:30.068570+00:00.
+
 - 🔎 **[BRiTE: Bootstrapping Reinforced Thinking Process to Enhance Language Model Reasoning](https://arxiv.org/abs/2501.18858)** — `discovery candidate`; awaiting primary-paper curation.  
   2025-01-31 · `direction-month-query` · `arxiv-monthly-backfill`  
   Labels: `SFT` · `Rejection Sampling` · `Reasoning` · `Code`  
@@ -4343,6 +4425,106 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
   Labels: `Self-improvement` · `Reasoning`  
   Authors: Yiwei Qin, Yixiu Liu, Pengfei Liu
 
+<a id="2024"></a>
+
+## 2024
+
+<a id="2024-12"></a>
+
+### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-11"></a>
+
+### November
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-10"></a>
+
+### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-09"></a>
+
+### September
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-08"></a>
+
+### August
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-07"></a>
+
+### July
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-06"></a>
+
+### June
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-05"></a>
+
+### May
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-04"></a>
+
+### April
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-03"></a>
+
+### March
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-02"></a>
+
+### February
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
+<a id="2024-01"></a>
+
+### January
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
+
+_No visible paper records in this cell yet._
+
 <a id="2023"></a>
 
 ## 2023
@@ -4350,6 +4532,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2023-10"></a>
 
 ### October
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[UltraFeedback: Boosting Language Models with Scaled AI Feedback](https://arxiv.org/abs/2310.01377)** — Builds large-scale fine-grained preference data by having strong models critique and score multiple responses.  
   2023-10-02 · `ai-feedback` · `preference-data` · `synthetic-data`  
@@ -4364,6 +4548,8 @@ Curated entries include a reviewed key idea and tags. 🔎 entries were found di
 <a id="2022-12"></a>
 
 ### December
+
+> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.
 
 - **[Self-Instruct: Aligning Language Models with Self-Generated Instructions](https://arxiv.org/abs/2212.10560)** — Bootstraps diverse instruction-following data from a model using filtering before supervised fine-tuning.  
   2022-12-20 · `synthetic-data` · `instruction-tuning` · `self-generation`  

--- a/radar/render.py
+++ b/radar/render.py
@@ -38,17 +38,25 @@ def all_records() -> list[dict]:
     return curated
 
 
-def render_papers(records: list[dict], year_level: int = 2) -> str:
+def render_papers(
+    records: list[dict],
+    year_level: int = 2,
+    month_keys: list[str] | None = None,
+    audit: dict[str, dict] | None = None,
+) -> str:
     from radar.labels import effective_labels, label_index
 
     label_names = {key: value["title"] for key, value in label_index().items()}
     sections: list[str] = []
-    years = sorted({str(paper["date"])[:4] for paper in records}, reverse=True)
+    audit = audit or {}
+    month_keys = month_keys or sorted({str(paper["date"])[:7] for paper in records}, reverse=True)
+    years = sorted({month[:4] for month in month_keys}, reverse=True)
     for year in years:
         sections.append(f"<a id=\"{year}\"></a>\n\n{'#' * year_level} {year}\n")
         by_year = [paper for paper in records if str(paper["date"]).startswith(year)]
-        months = sorted({str(paper["date"])[5:7] for paper in by_year}, reverse=True)
+        months = [month_key[5:7] for month_key in month_keys if month_key.startswith(year)]
         for month in months:
+            month_key = f"{year}-{month}"
             month_name = dt.date(2000, int(month), 1).strftime("%B")
             sections.append(f"<a id=\"{year}-{month}\"></a>\n\n{'#' * (year_level + 1)} {month_name}\n")
             by_month = sorted(
@@ -56,6 +64,27 @@ def render_papers(records: list[dict], year_level: int = 2) -> str:
                 key=lambda paper: str(paper["date"]),
                 reverse=True,
             )
+            cell = audit.get(month_key)
+            if not cell:
+                sections.append(
+                    "> **Audit status:** ⏳ Not audited yet. No completeness claim is made for this direction-month cell.\n"
+                )
+            elif cell.get("error"):
+                sections.append(
+                    f"> **Audit status:** ⚠ Failed — `{cell['error']}` · checked {cell.get('checked_at', 'time unavailable')}.\n"
+                )
+            elif cell.get("complete"):
+                sections.append(
+                    f"> **Audit status:** ✓ Complete · scanned {cell.get('records_scanned', 0)} academic records · "
+                    f"{cell.get('eligible', 0)} eligible · checked {cell.get('checked_at', 'time unavailable')}.\n"
+                )
+            else:
+                sections.append(
+                    f"> **Audit status:** ◐ Incomplete or truncated · scanned {cell.get('records_scanned', 0)} academic records · "
+                    f"{cell.get('eligible', 0)} eligible · checked {cell.get('checked_at', 'time unavailable')}.\n"
+                )
+            if not by_month:
+                sections.append("_No visible paper records in this cell yet._\n")
             for paper in by_month:
                 labels = " · ".join(f"`{label_names[label]}`" for label in effective_labels(paper))
                 if paper.get("discovery_candidate"):
@@ -115,14 +144,12 @@ def direction_page(direction: dict, records: list[dict]) -> str:
                 state = "✓" if cell and cell.get("complete") and not cell.get("error") else "◐"
                 month_items.append(f"[{month_name}](#{month_key}) {state}{count}")
             elif cell and cell.get("complete") and not cell.get("error"):
-                month_items.append(f"{month_name} ✓0")
+                month_items.append(f"[{month_name}](#{month_key}) ✓0")
             elif cell and (cell.get("error") or not cell.get("complete")):
-                month_items.append(f"{month_name} ⚠")
+                month_items.append(f"[{month_name}](#{month_key}) ⚠")
             else:
-                month_items.append(f"{month_name} ⏳")
-        year_has_papers = any(str(paper["date"]).startswith(year) for paper in selected)
-        year_label = f"[{year}](#{year})" if year_has_papers else year
-        directory.append(f"- {year_label} — " + " · ".join(month_items))
+                month_items.append(f"[{month_name}](#{month_key}) ⏳")
+        directory.append(f"- [{year}](#{year}) — " + " · ".join(month_items))
     return (
         f"# {direction['title']}\n\n"
         "[← Back to the atlas](../README.md)\n\n"
@@ -133,7 +160,7 @@ def direction_page(direction: dict, records: list[dict]) -> str:
         "`✓N` audited with N visible records · `✓0` audited with no eligible record · `◐N` records exist but the month audit is incomplete · `⏳` not audited · `⚠` failed or truncated.\n\n"
         + "\n".join(directory)
         + "\n\n"
-        + render_papers(selected)
+        + render_papers(selected, month_keys=displayed_months, audit=audit)
     )
 
 


### PR DESCRIPTION
Every direction page now links every month from 2024-01 through the latest completed month, including pending, failed, incomplete, and audited-zero cells. Each month section records its audit state, scanned and eligible counts, and checked time when available.