### PR TITLE
feat: package atlas as portable research skill

### DIFF
--- a/integrations/post-training-atlas/.codex-plugin/plugin.json
+++ b/integrations/post-training-atlas/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "post-training-atlas",
+  "version": "0.1.0",
+  "description": "Track post-training method evolution, compare iterations, and turn research signals into evidence-grounded ideas.",
+  "author": {
+    "name": "undefinted",
+    "url": "https://github.com/undefinted"
+  },
+  "homepage": "https://undefinted.github.io/Awesome-Post-Training-Atlas/",
+  "repository": "https://github.com/undefinted/Awesome-Post-Training-Atlas",
+  "license": "MIT",
+  "keywords": ["post-training", "research", "method-evolution", "agents", "vibe-coding"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Post-Training Atlas",
+    "shortDescription": "Track method evolution and research ideas.",
+    "longDescription": "A research skill for following post-training method families across language, reasoning, agents, multimodal, generative, and embodied models; comparing what changed; and turning evidence into testable ideas or coding plans.",
+    "developerName": "undefinted",
+    "category": "Research",
+    "capabilities": ["Research", "Idea generation", "Vibe coding"],
+    "websiteURL": "https://undefinted.github.io/Awesome-Post-Training-Atlas/",
+    "brandColor": "#3157D5",
+    "defaultPrompt": [
+      "Track the evolution of a post-training method and cite primary papers.",
+      "Use the atlas to find transferable ideas for my research problem.",
+      "Turn this post-training research brief into a careful coding plan."
+    ]
+  }
+}

--- a/integrations/post-training-atlas/README.md
+++ b/integrations/post-training-atlas/README.md
@@ -1,0 +1,30 @@
+# Post-Training Atlas plugin
+
+This directory packages the atlas as a reusable research skill.
+
+It has two layers:
+
+- `.codex-plugin/plugin.json` makes it discoverable as a Codex plugin.
+- `skills/post-training-atlas/` contains the tool-agnostic Markdown skill, UI metadata, and focused references.
+
+The skill is intentionally portable. In Codex, install the plugin through the normal local-plugin flow. In another harness, load `skills/post-training-atlas/SKILL.md` as a project/system instruction and make the repository root available as the atlas workspace. The instructions do not require a proprietary model or a specific MCP server.
+
+See `skills/post-training-atlas/references/harness-interop.md` for the portable loading contract and query-script example.
+
+## What it does
+
+1. Tracks how post-training method families evolve instead of only counting papers.
+2. Compares data, objectives, feedback, optimization, and transfer changes.
+3. Extracts cautious, testable cross-method research ideas.
+4. Turns a research brief into a repository-aware vibe-coding plan.
+5. Preserves the atlas rules: primary-source evidence, visible candidate status, provenance, and no guessed metadata.
+
+## Example prompts
+
+- “Use the Post-Training Atlas to explain how GRPO-style methods changed across recent variants.”
+- “Find transferable ideas between verifier training and interactive agents; separate evidence from hypotheses.”
+- “Research this post-training feature, then turn it into a minimal implementation plan for this repository.”
+
+## Repository-aware commands
+
+When working from the atlas root, the skill can use the existing radar and validation commands documented in the main README. The plugin does not silently publish or merge updates; review remains explicit.

--- a/integrations/post-training-atlas/skills/post-training-atlas/SKILL.md
+++ b/integrations/post-training-atlas/skills/post-training-atlas/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: post-training-atlas
+description: Track post-training method evolution across language, reasoning, agents, multimodal, generative, and embodied models; compare what changed between papers; extract transferable research ideas; and turn evidence into careful vibe-coding plans.
+---
+
+# Post-Training Atlas
+
+Use this skill when the user wants to understand, compare, update, or build on post-training methods. The primary goal is **method-evolution tracking**, not maximizing a paper count.
+
+## Core outcome
+
+Produce an evidence-grounded map that answers:
+
+1. What method family or pipeline stage is this work changing?
+2. What changed relative to the closest prior work?
+3. What evidence supports the claimed improvement, and what remains uncertain?
+4. Which design ideas appear transferable to another model, task, or modality?
+
+The atlas covers language and reasoning models, agents, VLM/MLLM systems, diffusion or video models, and embodied/VLA systems. Use the repository taxonomy as the navigation layer, not as a claim that every boundary is settled.
+
+## Select a mode
+
+- **Track a method:** build a chronological family timeline and a "what changed" matrix. Read [method-evolution.md](references/method-evolution.md).
+- **Find research ideas:** compare compatible mechanisms across families, then propose falsifiable hypotheses and experiments. Read [idea-generation.md](references/idea-generation.md).
+- **Support vibe coding:** research first, write a compact evidence brief, then translate it into implementation constraints and a verification plan. Read [vibe-coding.md](references/vibe-coding.md).
+- **Use another harness:** keep the Markdown contract and optional query helper; read [harness-interop.md](references/harness-interop.md).
+- **Maintain the atlas:** use the repository's radar, labels, rendering, coverage, and test commands; preserve provenance and keep discovery candidates visibly provisional.
+
+## Evidence and freshness rules
+
+- Prefer primary sources: arXiv records, official proceedings or publisher pages, author-maintained project pages, and the paper's official repository.
+- Community posts and social media can suggest a search term or popularity signal, but are not sufficient evidence for a paper entry or a method claim.
+- Separate publication date, revision date, and venue date. Do not infer a conference acceptance year from an arXiv record.
+- Display a venue only when structured academic metadata supports it. Do not guess author institutions, acceptance status, or method ancestry.
+- Mark every synthesized statement as one of: **reported by authors**, **observed from comparison**, or **hypothesis/inference**.
+- When the user asks for "latest," retrieve fresh primary-source evidence before making claims.
+
+## Repository workflow
+
+When the atlas repository is available, inspect the relevant files before answering:
+
+- `TAXONOMY.md` - inclusion boundaries and primary directions.
+- `data/papers.yaml` - curated entries.
+- `data/candidates.yaml` - academic discovery candidates; do not treat these as endorsements.
+- `config/labels.yaml` - controlled label vocabulary.
+- `data/monthly_audit.yaml` and `COVERAGE.md` - direction/month audit state.
+- `docs/index.html` - searchable website payload and current UI behavior.
+
+For a maintenance task, prefer the existing commands rather than inventing a parallel pipeline:
+
+```bash
+python -m radar.main --days 7
+python -m radar.monthly --auto
+python -m radar.labels
+python -m radar.render --check
+python -m radar.coverage --check
+python -m unittest discover -s tests
+```
+
+Automated discovery creates proposals. Keep curation, rejection, provenance, and review status explicit. Do not silently rewrite curated entries.
+
+## Default response shape
+
+For a method question, answer in this order:
+
+1. **Short thesis:** the method's central change.
+2. **Timeline:** baseline -> key variants -> current frontier.
+3. **Change matrix:** data, objective, feedback/reward, optimization, model/task scope, efficiency.
+4. **Evidence and caveats:** reported results, comparison limits, missing evidence.
+5. **Transferable ideas:** 2-5 concrete hypotheses, each with a rationale and a test.
+
+For a vibe-coding question, do not jump straight to code. First produce the research brief and implementation contract described in [vibe-coding.md](references/vibe-coding.md), then implement only when the user asks for the change.

--- a/integrations/post-training-atlas/skills/post-training-atlas/agents/openai.yaml
+++ b/integrations/post-training-atlas/skills/post-training-atlas/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Post-Training Atlas"
+  short_description: "Track method evolution and research ideas."
+  brand_color: "#3157D5"
+  default_prompt: "Use $post-training-atlas to compare a post-training method family and suggest testable ideas."
+
+policy:
+  allow_implicit_invocation: true

--- a/integrations/post-training-atlas/skills/post-training-atlas/references/harness-interop.md
+++ b/integrations/post-training-atlas/skills/post-training-atlas/references/harness-interop.md
@@ -1,0 +1,32 @@
+# Harness interoperability
+
+The core skill is Markdown plus one optional Python query helper. This keeps the research behavior portable across agent harnesses.
+
+## Codex
+
+- Install the plugin directory containing `.codex-plugin/plugin.json`.
+- Codex can discover `skills/post-training-atlas/SKILL.md` and its `agents/openai.yaml` metadata.
+- When the atlas repository is open, use its local YAML files and validation commands.
+
+## Other harnesses, including DeepSeek-based harnesses
+
+- Load `skills/post-training-atlas/SKILL.md` as a system, project, or agent instruction according to that harness’s normal skill-loading convention.
+- Expose the atlas repository as the working directory or pass it to `scripts/query_atlas.py --root <repo>`.
+- Read only the references needed for the selected mode.
+- If the harness has no skill registry, the folder still works as a prompt bundle: the Markdown entrypoint is the contract and the Python script is the optional deterministic data interface.
+
+Do not assume that another harness understands Codex-specific UI metadata, marketplace files, or tool names. The research contract must remain usable without them.
+
+## Portable invocation examples
+
+```bash
+python skills/post-training-atlas/scripts/query_atlas.py \
+  --root /path/to/Awesome-Post-Training-Atlas \
+  --direction agentic --year 2025 --label RLVR --json
+```
+
+```text
+Use the post-training-atlas skill. Track the evolution of [method family].
+Use primary sources, separate reported evidence from hypotheses, and end with
+transferable ideas plus the smallest falsifiable experiment.
+```

--- a/integrations/post-training-atlas/skills/post-training-atlas/references/idea-generation.md
+++ b/integrations/post-training-atlas/skills/post-training-atlas/references/idea-generation.md
@@ -1,0 +1,53 @@
+# Transferable-idea workflow
+
+Use this reference when the user wants research inspiration rather than a paper summary.
+
+## 1. Select source mechanisms
+
+Choose two or more mechanisms from different families or pipeline stages. Examples:
+
+- verifier-guided feedback + multi-turn agent trajectories;
+- on-policy distillation + multimodal instruction tuning;
+- outcome-level rewards + embodied action traces;
+- synthetic data selection + preference optimization.
+
+Do not combine methods merely because their names are popular. State the common interface: data, signal, policy, state/trajectory, or evaluation loop.
+
+## 2. Check compatibility
+
+For each proposed transfer, ask:
+
+- Does the target setting expose the same kind of feedback?
+- Can the source signal be computed at the target time scale?
+- Does the target model produce the states, actions, or traces the method expects?
+- What changes in credit assignment, data quality, or compute cost?
+- Could the method fail because the target modality has different observability or reward sparsity?
+
+## 3. Write a falsifiable hypothesis
+
+Use this format:
+
+> If we transfer **[mechanism]** from **[source setting]** to **[target setting]**, while holding **[controls]** fixed, then **[measurable outcome]** should improve because **[mechanistic rationale]**.
+
+Include a failure prediction:
+
+> The idea is likely to fail when **[condition]**, which should appear as **[diagnostic]**.
+
+## 4. Propose the smallest experiment
+
+Specify:
+
+1. baseline and one changed component;
+2. data or trajectory budget;
+3. primary metric and at least one quality/safety metric;
+4. ablations that distinguish the mechanism from extra compute or data;
+5. expected outcome and stop condition.
+
+Keep speculative ideas clearly labeled as hypotheses. A good idea is not a claim that the source paper already validates the target setting.
+
+## 5. Idea ledger
+
+For multiple ideas, use:
+
+| Idea | Source mechanisms | Target | Expected benefit | Main risk | Cheapest test | Confidence |
+|---|---|---|---|---|---|---|

--- a/integrations/post-training-atlas/skills/post-training-atlas/references/method-evolution.md
+++ b/integrations/post-training-atlas/skills/post-training-atlas/references/method-evolution.md
@@ -1,0 +1,52 @@
+# Method-evolution brief
+
+Use this reference for a method-family or “what changed?” request.
+
+## Normalize each paper
+
+Record only what the source supports:
+
+| Field | What to capture |
+|---|---|
+| Method family | The shared mechanism, not only the title acronym |
+| Baseline | Closest prior method or training pipeline |
+| Change axis | Data, objective, feedback/reward, sampling, optimizer, model scope, task scope, or efficiency |
+| Mechanism | One or two sentences describing the actual change |
+| Evidence | Dataset, benchmark, ablation, scaling result, or robustness result |
+| Reported limitation | Limitation stated by the authors |
+| Transfer surface | Model, task, modality, or stage where the idea may transfer |
+| Confidence | High when directly supported; medium for careful comparison; low for an inference |
+
+## Compare variants
+
+Use a compact matrix instead of a title dump:
+
+| Variant | What changed? | Why, according to the source? | Evidence | Cost/risk |
+|---|---|---|---|---|
+| Baseline | — | — | — | — |
+| Variant A | ... | reported / inferred | ... | ... |
+| Variant B | ... | reported / inferred | ... | ... |
+
+Do not call two papers a method family only because they share a keyword. Require a shared training mechanism, explicit predecessor relationship, or a defensible pipeline-level correspondence.
+
+## Explain “why” carefully
+
+- **Reported:** the paper explicitly motivates the change or demonstrates it in an ablation.
+- **Observed:** the comparison shows a consistent difference, but the authors do not establish causality.
+- **Hypothesis:** a plausible explanation or transfer idea that still needs testing.
+
+Never turn “the later paper performs better” into “the new component caused the gain” without an ablation or controlled comparison.
+
+## Timeline wording
+
+Prefer:
+
+> The family moves from [baseline mechanism] toward [later mechanism]. The main changes are [axes]. The evidence is strongest for [claim]; whether the gain transfers to [new setting] remains open.
+
+Avoid:
+
+> This is the definitive successor / best method / final version.
+
+## Useful labels
+
+Use the repository’s controlled vocabulary where possible, including `OPD`, `OPSD`, `counterfactual`, `distillation`, `RLVR`, `agent`, `VLM`, and `VLA`. Add a new label only when it describes a reusable mechanism and can be defined unambiguously.

--- a/integrations/post-training-atlas/skills/post-training-atlas/references/vibe-coding.md
+++ b/integrations/post-training-atlas/skills/post-training-atlas/references/vibe-coding.md
@@ -1,0 +1,45 @@
+# Research-to-vibe-coding workflow
+
+Use this reference when the user wants an AI coding agent to research post-training methods and then modify a project.
+
+## Phase A — research brief
+
+Before editing code, produce:
+
+- the target capability and user-visible outcome;
+- the relevant method family and 3–8 primary sources;
+- a short “what changed” comparison;
+- assumptions, open questions, and evidence gaps;
+- the smallest useful implementation slice.
+
+## Phase B — implementation contract
+
+Translate the brief into:
+
+| Item | Required decision |
+|---|---|
+| Inputs | Data, metadata, prompts, trajectories, or API responses |
+| Outputs | Files, UI behavior, reports, or model artifacts |
+| Invariants | Provenance, deduplication, labels, safety, reproducibility |
+| Non-goals | What will not be implemented in this change |
+| Verification | Tests, fixtures, checks, and an evidence review |
+
+Keep research claims separate from implementation decisions. A paper’s result is not automatically a production requirement.
+
+## Phase C — repository-aware execution
+
+- Inspect existing architecture and conventions before adding a new abstraction.
+- Reuse the atlas taxonomy, data schema, controlled labels, and radar commands when extending this repository.
+- Keep primary-source URLs and retrieval dates with new records.
+- Mark automatically discovered records as candidates until reviewed.
+- Prefer a small, reversible change and run the project’s tests and reproducibility checks.
+
+## Phase D — report back
+
+End with:
+
+1. what was researched;
+2. what was changed;
+3. which claims are sourced versus inferred;
+4. validation results;
+5. known limitations and a safe next step.

--- a/integrations/post-training-atlas/skills/post-training-atlas/scripts/query_atlas.py
+++ b/integrations/post-training-atlas/skills/post-training-atlas/scripts/query_atlas.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Query the Awesome-Post-Training-Atlas YAML data from any compatible harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - exercised by the user environment
+    raise SystemExit("PyYAML is required. Install the atlas repository requirements first.") from exc
+
+
+def load_records(root: Path) -> list[dict[str, Any]]:
+    records: dict[str, dict[str, Any]] = {}
+    for filename in ("data/papers.yaml", "data/candidates.yaml"):
+        path = root / filename
+        if not path.exists():
+            continue
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for paper in payload.get("papers", []):
+            key = str(paper.get("id", "")).lower()
+            if not key:
+                continue
+            if key not in records:
+                records[key] = dict(paper)
+                continue
+            current = records[key]
+            for field in ("direction_hints", "source_signals", "matched_queries", "auto_labels"):
+                values = sorted(set(current.get(field, [])) | set(paper.get(field, [])))
+                if values:
+                    current[field] = values
+            for field in ("code", "huggingface", "venue", "venue_type", "venue_url", "institutions"):
+                if paper.get(field) and not current.get(field):
+                    current[field] = paper[field]
+    return list(records.values())
+
+
+def matches(paper: dict[str, Any], args: argparse.Namespace) -> bool:
+    haystack = " ".join(
+        str(value)
+        for value in (
+            paper.get("title", ""),
+            paper.get("abstract", ""),
+            paper.get("key_idea", ""),
+            " ".join(paper.get("tags", [])),
+            " ".join(paper.get("auto_labels", [])),
+        )
+    ).lower()
+    if args.query and args.query.lower() not in haystack:
+        return False
+    direction_ids = set(paper.get("direction_hints", []))
+    direction_ids.add(paper.get("direction") or paper.get("suggested_direction"))
+    if args.direction and args.direction not in direction_ids:
+        return False
+    date = str(paper.get("date", ""))
+    if args.year and not date.startswith(str(args.year)):
+        return False
+    if args.month and date[:7] != args.month:
+        return False
+    labels = set(paper.get("auto_labels", [])) | set(paper.get("tags", []))
+    if args.label and not set(args.label).issubset(labels):
+        return False
+    if args.status:
+        discovery = bool(paper.get("discovery_candidate")) or paper.get("status") == "candidate"
+        status = "discovery" if discovery else "curated"
+        if status != args.status:
+            return False
+    return True
+
+
+def compact(paper: dict[str, Any]) -> dict[str, Any]:
+    keys = (
+        "id",
+        "title",
+        "date",
+        "direction",
+        "url",
+        "key_idea",
+        "tags",
+        "auto_labels",
+        "authors",
+        "institutions",
+        "venue",
+        "venue_type",
+        "discovery_candidate",
+    )
+    result = {key: paper[key] for key in keys if paper.get(key) not in (None, [], "")}
+    if "direction" not in result:
+        result["direction"] = paper.get("suggested_direction") or (paper.get("direction_hints") or [None])[0]
+    result["status"] = "discovery" if paper.get("discovery_candidate") or paper.get("status") == "candidate" else "curated"
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="Atlas repository root")
+    parser.add_argument("--query", help="Search title, abstract, key idea, tags, and labels")
+    parser.add_argument("--direction", help="Primary direction ID, e.g. agentic")
+    parser.add_argument("--year", type=int)
+    parser.add_argument("--month", help="YYYY-MM")
+    parser.add_argument("--label", action="append", help="Require a label; repeat for ALL semantics")
+    parser.add_argument("--status", choices=("curated", "discovery"))
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    results = [paper for paper in load_records(args.root) if matches(paper, args)]
+    results.sort(key=lambda paper: (str(paper.get("date", "")), str(paper.get("title", ""))), reverse=True)
+    results = [compact(paper) for paper in results[: max(args.limit, 0)]]
+    if args.as_json:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+        return
+    for paper in results:
+        labels = ", ".join(paper.get("auto_labels", []) or paper.get("tags", []))
+        print(f"- {paper.get('title', 'Untitled')} ({paper.get('date', '?')}) [{paper.get('direction', '?')}]" + (f" · {labels}" if labels else ""))
+        print(f"  {paper.get('url', '')}")
+    print(f"\nMatched {len(results)} record(s). Use --json for structured output.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this adds
- package Awesome-Post-Training-Atlas as a Codex plugin under integrations/post-training-atlas
- add a portable post-training-atlas skill for method-evolution tracking
- add focused workflows for method comparison, transferable idea generation, and research-to-vibe-coding
- preserve primary-source, provenance, candidate-status, and no-guessed-metadata rules
- add a deterministic YAML query helper usable from other agent harnesses
- document Codex and generic/DeepSeek-style harness loading without requiring proprietary tools

## Intended use
The main job is tracking how post-training method families evolve. Idea generation and vibe coding are secondary modes that must remain evidence-grounded and distinguish reported results from hypotheses.

## Validation
- skill-creator quick_validate passed
- plugin validator passed
- query helper tested against the atlas data